### PR TITLE
Month and Year not setting after clicking

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -578,6 +578,7 @@
                                     if (target[0].className === 'prev') step = step * -1;
                                     vd['set' + navFnc](vd['get' + navFnc]() + step);
                                     this.fillDate();
+                                    this.set();
                                     break;
                             }
                             break;
@@ -603,6 +604,7 @@
                             }
                             this.showMode(-1);
                             this.fillDate();
+                            this.set();
                             break;
                         case 'td':
                             if (target.is('.day')) {


### PR DESCRIPTION
Missing this.set(); tested with BS3.
