### PR TITLE
Fixed #5 by getting offset and outerHeight

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -273,9 +273,9 @@
 
         place: function () {
             var position = 'absolute';
-            var offset = this.component ? this.component.offset() : this.$element.offset();
+            var offset = (typeof this.component.offset() !== 'undefined') ? this.component.offset() : this.$element.offset();
             this.width = this.component ? this.component.outerWidth() : this.$element.outerWidth();
-            offset.top = offset.top + this.height;
+            offset.top = offset.top + this.$element.outerHeight();
 
             var $window = $(window);
 


### PR DESCRIPTION
Fixed https://github.com/Eonasdan/bootstrap-datetimepicker/issues/5.  I tried to run the tests but kept running into errors, the last of which was:

$ make test
mkdir -p build/js
mkdir -p build/css
aborting
Fontconfig warning: "/etc/fonts/conf.d/50-user.conf", line 9: reading configurations from ~/.fonts.conf is deprecated.
TypeError: 'undefined' is not a function (evaluating 'mocha.ui('bdd')')

  file:///home/tim/Documents/MyWebPages/arwd/projects/backbone/_attachments/js/vendor/bootstrap-datetimepicker/test/test.html:25
make: **\* [test] Error 1
