### PR TITLE
Remove redundant spaces left in formatDate()

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -875,7 +875,7 @@
                 if (methodName === 'getUTCMonth') rv = rv + 1;
                 if (methodName === 'getUTCYear') rv = rv + 1900 - 2000;
                 return padLeft(rv.toString(), len, '0');
-            });
+            }).trim();
         },
 
         parseDate: function (str) {


### PR DESCRIPTION
This bug put redundant spaces to input element, causing validation error if used under some web framework.
