### PR TITLE
Fix to output new date in local time to input element

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -181,7 +181,7 @@
             var formatted = '';
             if (!this._unset) {
 				if (this.useMoment) {
-					formatted = moment(this._date).format(this.format);
+					formatted = moment.utc(this._date).format(this.format);
 				}
 				else {
 					formatted = this.formatDate(this._date);


### PR DESCRIPTION
At least when I use a BackGrid moment cell configured like the one below, I have to make this change to bootstrap-datetimepicker.js to get it to output dates in the same time zone as what is displayed in the datetimepicker itself.  The BackGrid moment cell then takes care of converting it to UTC.

```
          cell: Backgrid.Extension.MomentCell.extend({
              modelInUTC: true,
              // This should convert the data to display in local time
              displayInUTC: false,
              modelFormat: "YYYY-MM-DD HH:mm:ss.SSSSSS",
              displayFormat: "YYYY-MM-DD HH:mm:ss",
              className: 'datetimepicker'
          })
```
