### PR TITLE
Update bootstrap-datetimepicker.js

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -198,7 +198,7 @@
                 this.$element.val(formatted);
                 this._resetMaskPos(this.$element);
             }
-            if (!this.pickTime) this.hide();
+            if (!this.pickTime) this.widget.hide();
         },
 
         setValue: function (newDate) {


### PR DESCRIPTION
this was erroring out as it was not referencing the widget element.
