### PR TITLE
Exposed place method to be public. This was required in my project to re...

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -868,6 +868,10 @@
             }
         },
 
+        picker.place = function () {
+            place();
+        },
+
         picker.disable = function () {
             picker.element.find('input').prop('disabled', true);
             detachDatePickerEvents();


### PR DESCRIPTION
Exposed place method to be public. This was required in my project to reposition datetime pickers when page is scrolled, and datetime pickers are in bootstrap modal.
