### PR TITLE
Fixed an exception on destroy() if the host element isn't an .input-group

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -851,7 +851,8 @@
             detachDatePickerGlobalEvents();
             picker.widget.remove();
             picker.element.removeData('DateTimePicker');
-            picker.component.removeData('DateTimePicker');
+            if (picker.component)
+                picker.component.removeData('DateTimePicker');
         };
 
         picker.show = function (e) {


### PR DESCRIPTION
When `destroy()`ing a datetimepicker attached to a free `<input type="button">` that isn't part of a bootstrap `input-group`, `picker.component` is false, leading to an exception.
