### PR TITLE
Fix for IE8 calendar/time collapse

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -906,12 +906,22 @@
         },
 
         picker.disable = function () {
-            picker.element.find('input').prop('disabled', true);
+            var input = picker.element.find('input');
+            if(!input.prop('disabled')){
+            	return
+            }
+        
+            input.prop('disabled', true);
             detachDatePickerEvents();
         },
 
         picker.enable = function () {
-            picker.element.find('input').prop('disabled', false);
+            var input = picker.element.find('input');
+            if(!input.prop('disabled')){
+            	return
+            }	
+            
+            input.prop('disabled', false);
             attachDatePickerEvents();
         },
 


### PR DESCRIPTION
In IE8, if you call enable on a picker that's not disabled, the click handler code gets called twice on click. This causes the calendar to collapse and expand immediately making it appear that nothing is working. Making sure that an picker is disable before enabling (and vise versa) prevents these shenanigans and doesn't impact behavior on other browsers.
