### PR TITLE
Momentjs version issue seems to be fixed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Done! [Now take a look at the manual](http://eonasdan.github.io/bootstrap-dateti
 ## Manual installation
 
 ### [Moment.js](https://github.com/moment/moment)
-Datetimepicker requires moment.js in version 2.3.1 (we're working on supporting higher versions). This allows for better support for various date formats and locales. See [documentation](http://eonasdan.github.io/bootstrap-datetimepicker/) for examples. Check [Momentjs' homepage](http://momentjs.com/) for documentation on date formats. If you can't use moment.js there's still older version of datetimewidget [available here](https://github.com/Eonasdan/bootstrap-datetimepicker/tree/version1). 
+This allows for better support for various date formats and locales. See [documentation](http://eonasdan.github.io/bootstrap-datetimepicker/) for examples. Check [Momentjs' homepage](http://momentjs.com/) for documentation on date formats. If you can't use moment.js there's still older version of datetimewidget [available here](https://github.com/Eonasdan/bootstrap-datetimepicker/tree/version1). 
 
 ````html
 <script type="text/javascript" src="/path/to/moment.js"></script>


### PR DESCRIPTION
Removing the note about the mandatory version information since newer versions of momentjs seem to work fine.
