### PR TITLE
Prevent datetimepicker from overflowing bottom

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -254,6 +254,7 @@
             
             if($window.height() < offset.top + picker.widget.outerHeight()){
             	offset.bottom = 0;
+            	offset.left += 40; //avoid overlaying the datetime button
             	offset.top = 'auto';
             }
 


### PR DESCRIPTION
In a bootstrap modal, if the datetimepicker is near the bottom of the screen, the picker overflows the window height and the time icon becomes unreachable. This prevents the picker from moving below the bottom of the window.
