### PR TITLE
Get the momentjs lang by default

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -44,7 +44,7 @@
 (function ($, moment) {
     if (typeof moment === 'undefined') {
         alert("momentjs is requried");
-        throw new Error('momentjs is requried');
+        throw new Error('momentjs is required');
     };
 
     var dpgId = 0,
@@ -62,7 +62,7 @@
             startDate: new pMoment({ y: 1970 }),
             endDate: new pMoment().add(50, "y"),
             collapse: true,
-            language: "en",
+            language: pMoment.lang(),
             defaultDate: "",
             disabledDates: [],
             enabledDates: false,


### PR DESCRIPTION
When you set the global language on momentjs, the datepicker set the language to english by default.
Is better to set this by the momentjs object.

I also fixed a minor error in line 47: requried -> required
