### PR TITLE
Fix default minutes when using minuteStepping

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -196,11 +196,17 @@
             fillMonths();
             fillHours();
             fillMinutes();
-			fillSeconds();
+            fillSeconds();
             update();
             showMode();
             attachDatePickerEvents();
             if (picker.options.defaultDate !== "") picker.setValue(picker.options.defaultDate);
+            if (picker.options.minuteStepping !== 1) {
+                var rMinutes = picker.date.minutes();
+                var rInterval = picker.options.minuteStepping;
+                picker.date.minutes((Math.round(rMinutes/rInterval) * rInterval) % 60)
+                           .seconds(0);
+            }
         },
 
         dataToOptions = function () {


### PR DESCRIPTION
When using `minuteStepping` without a default date set, the datetimepicker uses a new date object as the base time. The minutes and seconds will thus not align to the minuteStepping units. So if I have minuteStepping set to 15 minutes and it's 3:18 when I create the datetimepicker, I'll be able to choose 3:33, 3:48 but not 3:30 or 3:45.

What this PR does is reset the minutes to a multiple of minuteStepping if it detects minuteStepping is a custom value.
