### PR TITLE
Fix documentation: change ```data-OPTION``` to ```data-date-OPTION```

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
                 <li><a href="#events">Events </a></li>
             </ul>
           </div>
-        </div>        
+        </div>
         <div class="col-md-9">
             <h1>Bootstrap datetimepicker <small>Date/time picker widget for Twitter Bootstrap v3</small>
             </h1>
@@ -46,7 +46,7 @@
                         This is documentation for version 2. You can still find the documentation for version 1 <a href="http://eonasdan.github.io/bootstrap-datetimepicker/version1/">here</a>
                     </p>
             </div>
-            
+
             <div id="example1">
                 <a name="example1"></a>
                 <h4>Minimum Setup</h4>
@@ -95,7 +95,7 @@
                 </div>
                 <hr />
             </div>
-           
+
             <div id="example2">
                 <a name="example2"></a>
                 <div class="callout-box callout-box-info">
@@ -233,7 +233,7 @@
                 <span class="p">});</span>
                 <span class="nx">$</span><span class="p">(</span><span class="s2">"#setStartDate"</span><span class="p">).</span><span class="nx">click</span><span class="p">(</span><span class="kd">function</span> <span class="p">()</span> <span class="p">{</span>
                     <span class="nx">$</span><span class="p">(</span><span class="s1">'#datetimepicker3'</span><span class="p">).</span><span class="nx">data</span><span class="p">(</span><span class="s2">"DateTimePicker"</span><span class="p">).</span><span class="nx">setStartDate</span><span class="p">(</span><span class="k">new</span> <span class="nb">Date</span><span class="p">(</span><span class="s2">"june 12, 2013"</span><span class="p">));</span>
-                <span class="p">});</span>                                
+                <span class="p">});</span>
                 <span class="nx">$</span><span class="p">(</span><span class="s2">"#setEndDate"</span><span class="p">).</span><span class="nx">click</span><span class="p">(</span><span class="kd">function</span> <span class="p">()</span> <span class="p">{</span>
                     <span class="nx">$</span><span class="p">(</span><span class="s1">'#datetimepicker3'</span><span class="p">).</span><span class="nx">data</span><span class="p">(</span><span class="s2">"DateTimePicker"</span><span class="p">).</span><span class="nx">setEndDate</span><span class="p">(</span><span class="k">new</span> <span class="nb">Date</span><span class="p">(</span><span class="s2">"july 4, 2013"</span><span class="p">));</span>
                 <span class="p">});</span>
@@ -411,7 +411,7 @@
                 </div>
                 <hr />
             </div>
-            
+
             <div id="example7">
                 <a name="example7"></a>
                 <div class="callout-box callout-box-info">
@@ -475,7 +475,7 @@
                 </div>
             <hr />
             </div>
-            
+
             <div id="example8">
                 <a name="example8"></a>
                 <div class="callout-box callout-box-info">
@@ -622,7 +622,7 @@
             <div id="options">
                 <a name="options"></a>
                 <div class="callout-box callout-box-info">
-                    Options<p>These options can also be set by <code>data-OPTION</code></p>
+                    Options<p>These options can also be set by <code>data-date-OPTION</code></p>
                 </div>
                 <div class="highlight highlight-javascript">
                     <pre>
@@ -644,13 +644,13 @@
     <span class="nx">up</span><span class="o">:</span>   <span class="s1">'glyphicon glyphicon-chevron-up'</span><span class="p">,</span>
     <span class="nx">down</span><span class="o">:</span> <span class="s1">'glyphicon glyphicon-chevron-down'</span>
     <span class="p">}</span>
-    <span class="nx">useStrict</span><span class="o">:</span> <span class="kc">false</span><span class="p">,</span>             <span class="c1">//use "strict" when validating dates</span>    
+    <span class="nx">useStrict</span><span class="o">:</span> <span class="kc">false</span><span class="p">,</span>             <span class="c1">//use "strict" when validating dates</span>
 <span class="p">};</span>
 </pre>
                 </div>
                 <hr />
             </div>
-            
+
             <div id="events">
                 <a name="events"></a>
                 <h4>Events</h4>


### PR DESCRIPTION
Fix documentation: change `data-OPTION` to `data-date-OPTION` for helper text. Also cleans up white-space and end of lines.
