### PR TITLE
Fix selecting month or year from month or year views with a valid date

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -526,7 +526,7 @@
                                 year = parseInt(target.text(), 10) || 0;
                                 picker.viewDate.year(year);
                             }
-                            if (picker.viewMode !== 0) {
+                            if (picker.viewMode === picker.minViewMode) {
                                 picker.date = pMoment({
                                     y: picker.viewDate.year(),
                                     M: picker.viewDate.month(),
@@ -664,7 +664,6 @@
         },
 
         change = function (e) {
-            if (picker.viewMode !== 0) return
             pMoment.lang(picker.options.language);
             var input = $(e.target), oldDate = pMoment(picker.date), newDate = pMoment(input.val(), picker.format, picker.options.useStrict);
             if (newDate.isValid() && !isInDisableDates(newDate) && isInEnableDates(newDate)) {


### PR DESCRIPTION
Fixes issue #196.

The easiest approach seems to be to leave the change method early if the viewMode isn't the day view.
