### PR TITLE
Updating the gem version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ PM> Install-Package Bootstrap.v3.Datetimepicker.CSS
 Add the following to your `Gemfile`:
 ```
 gem 'momentjs-rails', '~> 2.5.0'
-gem 'bootstrap3-datetimepicker-rails', '~> 2.1.30'
+gem 'bootstrap3-datetimepicker-rails', '~> 3.0.0'
 ```
 Read the rest of the install instructions @ 
 [TrevorS/bootstrap3-datetimepicker-rails](https://github.com/TrevorS/bootstrap3-datetimepicker-rails)


### PR DESCRIPTION
Changing the `bootstrap3-datetimepicker-rails` gem version to `3.0.0`.
