### PR TITLE
#228 - Fix issue with setValue not taking into account the format

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1105,7 +1105,7 @@ THE SOFTWARE.
             } else {
                 picker.unset = false;
             }
-            if (!pMoment.isMoment(newDate)) newDate = pMoment(newDate);
+            if (!pMoment.isMoment(newDate)) newDate = pMoment(newDate, picker.format);
             if (newDate.isValid()) {
                 picker.date = newDate;
                 set();


### PR DESCRIPTION
When you call setValue, it checks to see if the date passed in is a Moment date, if not it constructs a new Moment date, however it does not take into account the picker format, for example if I set the format to 'DD/MM/YYYY' and then call setValue with the parameter '03/02/2014', which in the UK should be the 3rd February 2014, it gets interpreted as 2nd March 2014 instead.
