### PR TITLE
Changed picker.show to hide when already open

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1048,7 +1048,14 @@ THE SOFTWARE.
                     }
                 };
             }
-            picker.widget.show();
+            if (picker.widget.hasClass("picker-open")) {
+            	picker.widget.hide();
+            	picker.widget.removeClass("picker-open");
+            }
+            else {
+            	picker.widget.show();
+            	picker.widget.addClass("picker-open");
+            }
             picker.height = picker.component ? picker.component.outerHeight() : picker.element.outerHeight();
             place();
             picker.element.trigger({


### PR DESCRIPTION
With this change it is possible to close the datetimepicker on the button it is opened when it's already open.

Short called this is normal toggle behaviour
