### PR TITLE
Use border-radius from bootstrap variables

### DIFF
--- a/src/less/bootstrap-datetimepicker.less
+++ b/src/less/bootstrap-datetimepicker.less
@@ -14,7 +14,7 @@
     padding: 4px;
     margin-top: 1px;
     z-index: 99999;
-    border-radius: 4px;
+    border-radius: @border-radius-base;
 
     .btn {
         padding:6px;
@@ -102,7 +102,7 @@
         text-align: center;
         width: 20px;
         height: 20px;
-        border-radius: 4px;
+        border-radius: @border-radius-base;
     }
 
     td
@@ -147,7 +147,7 @@
             float: left;
             margin: 2px;
             cursor: pointer;
-            border-radius: 4px;
+            border-radius: @border-radius-base;
 
             &:hover
             {


### PR DESCRIPTION
For better integration into other bootstrap projects @border-radius-base could be used instead of "hard-coded" border-radius
