### PR TITLE
Fixed a bug when rendering months with daylight saving time

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -363,6 +363,7 @@ THE SOFTWARE.
                 startMonth = picker.options.minDate.month(),
                 endYear = picker.options.maxDate.year(),
                 endMonth = picker.options.maxDate.month(),
+                currentDate,
                 prevMonth, nextMonth, html = [], row, clsName, i, days, yearCont, currentYear, months = pMoment.months();
 
             picker.widget.find('.datepicker-days').find('.disabled').removeClass('disabled');
@@ -414,7 +415,13 @@ THE SOFTWARE.
                     }
                 }
                 row.append('<td class="day' + clsName + '">' + prevMonth.date() + '</td>');
+
+                currentDate = prevMonth.date();
                 prevMonth.add(1, "d");
+
+                if (currentDate == prevMonth.date()) {
+                  prevMonth.add(1, "d");
+                }
             }
             picker.widget.find('.datepicker-days tbody').empty().append(html);
             currentYear = picker.date.year(), months = picker.widget.find('.datepicker-months')


### PR DESCRIPTION
Within the fillDate method, on line 386, there was a bug with the while:

```
while (prevMonth.isBefore(nextMonth)) {
```

When a day has less than 24 hours (23 because of daylight saving), the
following call will never reach the next day:

```
prevMonth.add(1, "d");
```

because prevMonth is at 00:00:00 hours.

To fix this, I moved prevMonth to 12:00:00 hours. In this case, the call
prevMonth.add(1, "d"); will always reach the next day.
