### PR TITLE
Prevent possibility to select NaN for an hour, minute and second value.

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -673,20 +673,26 @@ THE SOFTWARE.
 		    },
 
 		    selectHour: function (e) {
-		        var period = picker.widget.find('.timepicker [data-action=togglePeriod]').text(), hour = parseInt($(e.target).text(), 10);
-		        if (period == "PM") hour += 12
-		        picker.date.hours(hour);
-		        actions.showPicker.call(picker);
+		        if ($(e.target).is('.hour')) {
+		            var period = picker.widget.find('.timepicker [data-action=togglePeriod]').text(), hour = parseInt($(e.target).text(), 10);
+		            if (period == "PM") hour += 12
+		            picker.date.hours(hour);
+		            actions.showPicker.call(picker);
+		        }
 		    },
 
 		    selectMinute: function (e) {
-		        picker.date.minutes(parseInt($(e.target).text(), 10));
-		        actions.showPicker.call(picker);
+		        if ($(e.target).is('.minute')) {
+		            picker.date.minutes(parseInt($(e.target).text(), 10));
+		            actions.showPicker.call(picker);
+		        }
 		    },
 
 		    selectSecond: function (e) {
-		        picker.date.seconds(parseInt($(e.target).text(), 10));
-		        actions.showPicker.call(picker);
+		        if ($(e.target).is('.second')) {
+		            picker.date.seconds(parseInt($(e.target).text(), 10));
+		            actions.showPicker.call(picker);
+		        }
 		    }
 		},
 


### PR DESCRIPTION
Issue is affecting Chromium (my version is 33.0.1750.152). Only sideBySide: true options is used - http://jsfiddle.net/G3mfH/2/.

Steps to reproduce:
- Click the hour or minute value of the timepicker. List of hours/minutes appears.
- Click exactly between two values when no hover state is shown. 

![side-by-side_invalid_value_selected](https://cloud.githubusercontent.com/assets/4487978/2745514/57b321ea-c737-11e3-86e4-b9a197c2022d.png)
