### PR TITLE
Missing semi-colon

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -318,7 +318,7 @@ THE SOFTWARE.
             pMoment.lang(picker.options.language);
             var dateStr = newDate;
             if (!dateStr) {
-                dateStr = getPickerInput().val()
+                dateStr = getPickerInput().val();
                 if (dateStr) picker.date = pMoment(dateStr, picker.format, picker.options.useStrict);
                 if (!picker.date) picker.date = pMoment();
             }


### PR DESCRIPTION
Added to prevent problems when minifying JS
