### PR TITLE
Fix for #293 - Added notifyChange after input setValue on show

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1046,6 +1046,7 @@ THE SOFTWARE.
                     } else {
                         picker.setValue(pMoment().format(picker.format))
                     }
+                    notifyChange('', e.type);                    
                 };
             }
             picker.widget.show();


### PR DESCRIPTION
Fix for #293
NotifyChange is currently not triggered in picker.show. In angular this causes that new value is not binded to model as the change event has not been triggered.
