### PR TITLE
Fix selected date when time picker goes over the midnight.

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -852,11 +852,17 @@ THE SOFTWARE.
 		        return;
 		    }
 
+		    var daychange = picker.date.year() !== newdate.year() || picker.date.dayofyear() !== newdate.dayofyear();
+
 		    if (direction == "add") {
 		        picker.date.add(amount, unit);
 		    }
 		    else {
 		        picker.date.subtract(amount, unit);
+		    }
+
+		    if (dayChange) {
+		        fillDate();
 		    }
 		    picker.unset = false;
 		},


### PR DESCRIPTION
When both date and time picker are used and time is changed over the midnight, old date is still selected - http://jsfiddle.net/G3mfH/. 
