### PR TITLE
Enable datepicker to appendTo another element in the page

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -73,7 +73,8 @@ THE SOFTWARE.
             useStrict: false,
             direction: "auto",
             sideBySide: false,
-            daysOfWeekDisabled: false
+            daysOfWeekDisabled: false,
+            appendTo: 'body'
         },
 
 		icons = {
@@ -144,7 +145,7 @@ THE SOFTWARE.
                 }
             }
 
-            picker.widget = $(getTemplate()).appendTo('body');
+            picker.widget = $(getTemplate()).appendTo(picker.options.appendTo);
 
             if (picker.options.useSeconds && !picker.use24hours) {
                 picker.widget.width(300);
@@ -238,6 +239,11 @@ THE SOFTWARE.
         },
 
         place = function () {
+
+            if (picker.options.appendTo != defaults.appendTo) {
+                return;
+            }
+
             var position = 'absolute',
             offset = picker.component ? picker.component.offset() : picker.element.offset(), $window = $(window);
             picker.width = picker.component ? picker.component.outerWidth() : picker.element.outerWidth();


### PR DESCRIPTION
Due to a design decision, we needed to use absolute/relative positioning from an element to position the DatePicker, and have it appended to one of the elements hear the input it was to be used on.

This PR enables you to specify "appendTo: $jqueryObject" in the options list, and have the DatePicker added within the page, appended to that element.

The check on place() is simply to not update/apply any inline styles to the element if it's NOT attached directly to "body", which remains the default element if you specify no appendTo option.
