### PR TITLE
Reset timepicker view when popup is going to be displayed.

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1048,6 +1048,7 @@ THE SOFTWARE.
                     }
                 };
             }
+            actions.showPicker.call(picker);
             picker.widget.show();
             picker.height = picker.component ? picker.component.outerHeight() : picker.element.outerHeight();
             place();


### PR DESCRIPTION
This fix is resetting time picker view when the date and time picker are displayed side by side and the popup is closed with .timepicker-hour or .timepicker-minute selectors activated. 
