### PR TITLE
Use setDate instead of setValue when useCurrent enabled

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1044,15 +1044,13 @@ THE SOFTWARE.
         picker.show = function (e) {
             if (picker.options.useCurrent) {
                 if (getPickerInput().val() == '') {
+                    var mDate = pMoment();
                     if (picker.options.minuteStepping !== 1) {
-                        var mDate = pMoment(),
-                        rInterval = picker.options.minuteStepping;
+                        var rInterval = picker.options.minuteStepping;
                         mDate.minutes((Math.round(mDate.minutes() / rInterval) * rInterval) % 60)
                             .seconds(0);
-                        picker.setValue(mDate.format(picker.format))
-                    } else {
-                        picker.setValue(pMoment().format(picker.format))
                     }
+                    picker.setDate(mDate)
                 };
             }
             if (picker.widget.hasClass("picker-open")) {


### PR DESCRIPTION
This allows dp.change to be triggered, since setting the date to current is
actually a change and should be treated as so. This is useful for situations
where one needs to bind an event handler to the dp.change event. In case the
user actually wants to select the current date (which is preselected on show if using
useCurrent is true), the event is not triggered thus the event handler is not
fired properly, although intended.
