### PR TITLE
Fix bug when this picker is open and is pressed the escape key to close

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -712,6 +712,11 @@ THE SOFTWARE.
             e.preventDefault();
         },
 
+		keydown = function (e) {
+            if (e.keyCode === 27) // allow escape to hide picker
+                picker.hide();
+        },
+
         change = function (e) {
             pMoment.lang(picker.options.language);
             var input = $(e.target), oldDate = pMoment(picker.date), newDate = pMoment(input.val(), picker.format, picker.options.useStrict);
@@ -742,6 +747,7 @@ THE SOFTWARE.
             picker.widget.on('click', '.datepicker *', $.proxy(click, this)); // this handles date picker clicks
             picker.widget.on('click', '[data-action]', $.proxy(doAction, this)); // this handles time picker clicks
             picker.widget.on('mousedown', $.proxy(stopEvent, this));
+            picker.element.on('keydown', $.proxy(keydown, this));
             if (picker.options.pickDate && picker.options.pickTime) {
                 picker.widget.on('click.togglePicker', '.accordion-toggle', function (e) {
                     e.stopPropagation();


### PR DESCRIPTION
The datatimepicker don't closed when the escape key is pressed.
