### PR TITLE
Fix transitioning

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -752,7 +752,7 @@ THE SOFTWARE.
 
                     if (expanded && expanded.length) {
                         collapseData = expanded.data('collapse');
-                        if (collapseData && collapseData.date - transitioning) return;
+                        if (collapseData && collapseData.transitioning) return;
                         expanded.collapse('hide');
                         closed.collapse('show');
                         $this.find('span').toggleClass(picker.options.icons.time + ' ' + picker.options.icons.date);
@@ -1098,7 +1098,7 @@ THE SOFTWARE.
             var collapse = picker.widget.find('.collapse'), i, collapseData;
             for (i = 0; i < collapse.length; i++) {
                 collapseData = collapse.eq(i).data('collapse');
-                if (collapseData && collapseData.date - transitioning)
+                if (collapseData && collapseData.transitioning)
                     return;
             }
             picker.widget.hide();


### PR DESCRIPTION
There is global variable `transitioning`, which is not defined but used on lines 755, 1101.
When the collapse data is set in the bootstrap collapse plugin it leads to an issue.

Another fixed problem here is in the property `collapseData.date`. This property doesn't exists, you can use `collapseData.transitioning` instead, which has value `1` when the transition is active and value `0` otherwise.
