### PR TITLE
Fixed moment.js treating Date as an invalid date

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1101,7 +1101,7 @@ THE SOFTWARE.
             } else {
                 picker.unset = false;
             }
-            if (!pMoment.isMoment(newDate)) newDate = pMoment(newDate, picker.format);
+            if (!pMoment.isMoment(newDate)) newDate = (newDate instanceof Date) ? pMoment(newDate) : pMoment(newDate, picker.format);
             if (newDate.isValid()) {
                 picker.date = newDate;
                 set();


### PR DESCRIPTION
Calling moment.js ctor on a Date object with formatting argument makes it invalid.
