### PR TITLE
Discard the time component in min/max date setting to include same-day selection

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1144,13 +1144,15 @@ THE SOFTWARE.
 
         picker.setMaxDate = function (date) {
             if (date == undefined) return;
-            picker.options.maxDate = pMoment(date);
+            // Discard time component
+            picker.options.maxDate = pMoment(date.format("YYYY-MM-DD"));
             if (picker.viewDate) update();
         },
 
         picker.setMinDate = function (date) {
             if (date == undefined) return;
-            picker.options.minDate = pMoment(date);
+            // Discard time component
+            picker.options.minDate = pMoment(date.format("YYYY-MM-DD"));
             if (picker.viewDate) update();
         };
 


### PR DESCRIPTION
To reproduce the issue, call `setMinDate()` or `setMaxDate()` with a time component. For example, use `moment('2014-06-01 06:00")`. When you select from the calendar 2014-06-01, you'll notice that 2014-06-01 is disabled.

Fixes #409 and #337
