### PR TITLE
Discard the time component in min/max date setting to include same-day selection

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1145,14 +1145,14 @@ THE SOFTWARE.
         picker.setMaxDate = function (date) {
             if (date == undefined) return;
             // Discard time component
-            picker.options.maxDate = pMoment(date.format("YYYY-MM-DD"));
+            picker.options.maxDate = pMoment(pMoment(date).format("YYYY-MM-DD"));
             if (picker.viewDate) update();
         },
 
         picker.setMinDate = function (date) {
             if (date == undefined) return;
             // Discard time component
-            picker.options.minDate = pMoment(date.format("YYYY-MM-DD"));
+            picker.options.minDate = pMoment(pMoment(date).format("YYYY-MM-DD"));
             if (picker.viewDate) update();
         };
 


### PR DESCRIPTION
To reproduce, the issue call `setMinDate()` or `setMaxDate()` with a time component (e.g. `moment('2014-06-01 06:00')`.). When you select from 2014-06, June 1 will be disabled when it should not.

Fixes #409 and #337
