### PR TITLE
Reorder the unset so that event handlers can rectify the date if necessary

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -716,9 +716,9 @@ THE SOFTWARE.
             }
             else {
                 picker.viewDate = oldDate;
+                picker.unset = true;
                 notifyChange(oldDate, e.type);
                 notifyError(newDate);
-                picker.unset = true;
             }
         },
 


### PR DESCRIPTION
If an invalid date is specified and the change method is fired, the picker's `unset` flag will be set AFTER notifyError() is called. This prevents an event handler from recovering from the error (i.e. setting it to a reasonable default). Put the 'set' flag first so that event handlers can rectify the date if necessary.
