### PR TITLE
Revert "Fix issue with setValue not taking into account the format when ...

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1105,7 +1105,7 @@ THE SOFTWARE.
             } else {
                 picker.unset = false;
             }
-            if (!pMoment.isMoment(newDate)) newDate = pMoment(newDate, picker.format);
+            if (!pMoment.isMoment(newDate)) newDate = pMoment(newDate);
             if (newDate.isValid()) {
                 picker.date = newDate;
                 set();


### PR DESCRIPTION
...passing in a string"

This reverts commit bf5722dd35baf49fac31a1e74357987844eca87f.

This commit breaks the simple case: `setValue(moment())`
