### PR TITLE
Bugfix - dataToOptions

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -752,7 +752,7 @@ THE SOFTWARE.
                         expanded.collapse('hide');
                         closed.collapse('show');
                         $this.find('span').toggleClass(picker.options.icons.time + ' ' + picker.options.icons.date);
-                        picker.element.find('.input-group-addon span').toggleClass(picker.options.icons.time + ' ' + picker.options.icons.date);
+                        picker.element.find("[class^='input-group-'] span").toggleClass(picker.options.icons.time + ' ' + picker.options.icons.date);
                     }
                 });
             }


### PR DESCRIPTION
Hi, I use your repository as submodule in my gem. This gem packages your bootstrap-datetimepicker for Rails asset pipeline, and creates the Simple Form custom fields out of the box. My SimpleForm custom field implementation assumes to work the data-date-\* attributes correctly in your picker. I find out that, there is a bug in your dataToOptions function, and I have prepared this pull request to fix that issue. Please, accept this request.
