### PR TITLE
Use more-specific class in place of 'switch' to avoid common conflicts

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -545,7 +545,7 @@ THE SOFTWARE.
                     switch (target[0].nodeName.toLowerCase()) {
                         case 'th':
                             switch (target[0].className) {
-                                case 'switch':
+                                case 'picker-switch':
                                     showMode(1);
                                     break;
                                 case 'prev':
@@ -974,7 +974,7 @@ THE SOFTWARE.
             headTemplate:
                     '<thead>' +
                         '<tr>' +
-                            '<th class="prev">&lsaquo;</th><th colspan="5" class="switch"></th><th class="next">&rsaquo;</th>' +
+                            '<th class="prev">&lsaquo;</th><th colspan="5" class="picker-switch"></th><th class="next">&rsaquo;</th>' +
                         '</tr>' +
                     '</thead>',
             contTemplate:

--- a/src/less/bootstrap-datetimepicker.less
+++ b/src/less/bootstrap-datetimepicker.less
@@ -222,7 +222,7 @@
         line-height: 20px;
         width: 20px;
 
-        &.switch {
+        &.picker-switch {
             width: 145px;
         }
 


### PR DESCRIPTION
While working with bootstrap-datetimepicker I encountered a conflict with another library that's using the 'switch' class. By using the picker-switch class already present in this library, I was able to resolve the conflict. Seems like it could be a common problem.
