### PR TITLE
Fix anomally of year spans generation

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -441,7 +441,7 @@ THE SOFTWARE.
             html = '';
             year = parseInt(year / 10, 10) * 10;
             yearCont = picker.widget.find('.datepicker-years').find(
-                'th:eq(1)').text(year + '-' + (year + 9)).end().find('td');
+                'th:eq(1)').text(year + '-' + (year + 9)).parents('table').find('td');
             picker.widget.find('.datepicker-years').find('th').removeClass('disabled');
             if (startYear > year) {
                 picker.widget.find('.datepicker-years').find('th:eq(0)').addClass('disabled');


### PR DESCRIPTION
In my application I enable and disable datepickers on the same page constantly, and an issue came up where the year spans were not being generated, I singled it down to this line being `end()` wasn't working with jQuery@2.1.1

I don't know why, but this is how I fixed my own issue, if someone else has this issue later it is now documented.

![image](https://cloud.githubusercontent.com/assets/2925395/3750149/f8ea6c9c-17f2-11e4-9dfb-e9ac6c269cc3.png)
