### PR TITLE
fix for issue #456

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1226,6 +1226,8 @@ THE SOFTWARE.
             }
             if (!pMoment.isMoment(newDate)) {
                 newDate = (newDate instanceof Date) ? pMoment(newDate) : pMoment(newDate, picker.format, picker.options.useStrict);
+            } else {
+                newDate = newDate.locale(picker.options.language);
             }
             if (newDate.isValid()) {
                 picker.date = newDate;


### PR DESCRIPTION
Ensure that when a moment is passed in setValue, its locale is set to match the locale of the DateTimePicker.
