### PR TITLE
update composer.json to remove component/boostrap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
   "require": {
     "robloach/component-installer": "*",
     "components/jquery": ">=1.9.1",
-    "components/bootstrap": "3.*",
     "moment/moment": ">=2.8"
   },
   "extra": {


### PR DESCRIPTION
reason: 

twbs/bootstrap has a composer.json already, and includes all its components, many of which are needed if you want to run a post-install build process to combine and minify only a subset. This lets the resulting js/css files be much smaller.

component/bootstrap has the component .less files but not the .js files, and robloach/component-installer copies a lot of boostraps files into a <webroot>/component/ directory which is annoying and can't be turned off

removing the dependency allows us the choice. it is fairly obvious from the name of your project that bootstrap is a requirement
