### PR TITLE
[ADD] calendar week option

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -233,6 +233,9 @@ THE SOFTWARE.
             if (eData.dateUsecurrent !== undefined) {
                 picker.options.useCurrent = eData.dateUsecurrent;
             }
+            if (eData.calendarWeeks !== undefined) {
+                picker.options.calendarWeeks = eData.calendarWeeks;
+            }
             if (eData.dateMinutestepping !== undefined) {
                 picker.options.minuteStepping = eData.dateMinutestepping;
             }
@@ -386,7 +389,7 @@ THE SOFTWARE.
             moment.locale(picker.options.language);
             var html = $('<tr>'), weekdaysMin = moment.weekdaysMin(), i;
             if (picker.options.calendarWeeks === true) {
-                html.append('<th class="cw">&nbsp</th>');
+                html.append('<th class="cw">#</th>');
             }
             if (moment().localeData()._week.dow === 0) { // starts on Sunday
                 for (i = 0; i < 7; i++) {
@@ -1091,11 +1094,11 @@ THE SOFTWARE.
             headTemplate:
                     '<thead>' +
                         '<tr>' +
-                            '<th class="prev">&lsaquo;</th><th colspan="5" class="picker-switch"></th><th class="next">&rsaquo;</th>' +
+                            '<th class="prev">&lsaquo;</th><th colspan="' + (options.calendarWeeks ? '6' : '5') + '" class="picker-switch"></th><th class="next">&rsaquo;</th>' +
                         '</tr>' +
                     '</thead>',
             contTemplate:
-                    '<tbody><tr><td colspan="7"></td></tr></tbody>'
+                    '<tbody><tr><td colspan="' + (options.calendarWeeks ? '8' : '7') + '"></td></tr></tbody>'
         },
 
         tpGlobal = {
@@ -1347,7 +1350,7 @@ THE SOFTWARE.
         useMinutes: true,
         useSeconds: false,
         useCurrent: true,
-        calendarWeeks: true,
+        calendarWeeks: false,
         minuteStepping: 1,
         minDate: moment({y: 1900}),
         maxDate: moment().add(100, 'y'),

--- a/src/less/bootstrap-datetimepicker.less
+++ b/src/less/bootstrap-datetimepicker.less
@@ -137,6 +137,7 @@
             font-size: 10px;
             height: 20px;
             line-height: 20px;
+            color: @gray-light;
         }
 
         &.day


### PR DESCRIPTION
ability to show/hide week number on the left of the date widget.

Inspired from eternicode bootstrap datepicker: https://github.com/eternicode/bootstrap-datepicker/tree/release

preview: 
![calendarweeks](https://cloud.githubusercontent.com/assets/7338483/3892820/8070124c-2235-11e4-9e33-6cadf6d692dc.png)
