### PR TITLE
Updated 24hour detection

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -110,7 +110,7 @@ THE SOFTWARE.
                     }
                 }
             }
-            picker.use24hours = (picker.format.toLowerCase().indexOf('a') < 1 && picker.format.indexOf('h') < 1);
+            picker.use24hours = (picker.format.toLowerCase().indexOf('a') < 0 && picker.format.indexOf('h') < 0);
 
             if (picker.component) {
                 icon = picker.component.find('span');


### PR DESCRIPTION
Updated 24hour detection to look for lower case 'h' (12-hour clock hours) as well as case-insensitive 'a' (AM/PM marker), based on suggestions in #482
