### PR TITLE
Fix versions of jQuery and Bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   ],
   "dependencies": {
       "moment": "~2.8.1",
-      "bootstrap": "~3.0",
-      "jquery": "~1.8.3"
+      "bootstrap": "^3.0",
+      "jquery": "^1.8.3"
   },
   "devDependencies": {
     "grunt": "latest",


### PR DESCRIPTION
jQuery 1.8 doesn't work with browserify due to a bug in esprima triggered by
internal dependencies not up to date. And Bootstrap ~3.0 doesn't match any
version on npm. Changed matches to allow newer compatible versions.

See also Issue #503 and Issue #501.
