### PR TITLE
fixed time picker arrows box-shadow when active

### DIFF
--- a/src/less/bootstrap-datetimepicker.less
+++ b/src/less/bootstrap-datetimepicker.less
@@ -90,6 +90,10 @@
     a[data-action] {
       padding: 6px 0;
     }
+    
+    a[data-action]:active {
+        box-shadow: none;
+    }
 
     .timepicker-hour, .timepicker-minute, .timepicker-second {
         width: 54px;


### PR DESCRIPTION
before

![before](https://cloud.githubusercontent.com/assets/677646/4065347/ce76c6f8-2e19-11e4-9b1d-1e4f5c144ea1.png)

after

![after](https://cloud.githubusercontent.com/assets/677646/4065351/d69ed370-2e19-11e4-9a44-271a9c3eb2d8.png)

(note the box shadow for the pressed arrow)
