### PR TITLE
Development

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -219,7 +219,7 @@ THE SOFTWARE.
             }
             else {
                 input = picker.element.find('input');
-                if (input) {
+                if (input.length) {
                     eData = input.data();
                 } else {
                     eData = picker.element.data();

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -213,12 +213,12 @@ THE SOFTWARE.
         },
 
         dataToOptions = function () {
-            var eData;
+            var eData, input;
             if (picker.element.is('input')) {
                 eData = picker.element.data();
             }
             else {
-                var input = picker.element.find('input');
+                input = picker.element.find('input');
                 if (input) {
                     eData = input.data();
                 } else {


### PR DESCRIPTION
As I'm using datetimepicker attached to an <a> element and not to an input (see screenshot) I was getting an error at datepicker setup time.

With this tiny patch it verifies if the element has an input among children elements otherwise it will rely on the datapicker element by itself to load default options.