### PR TITLE
fix: unsubscribe from 'change' event using correct function

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -919,13 +919,13 @@ THE SOFTWARE.
             if (picker.isInput) {
                 picker.element.off({
                     'focus': picker.show,
-                    'change': picker.change,
+                    'change': change,
                     'click': picker.show,
                     'blur' : picker.hide
                 });
             } else {
                 picker.element.off({
-                    'change': picker.change
+                    'change': change
                 }, 'input');
                 if (picker.component) {
                     picker.component.off('click', picker.show);


### PR DESCRIPTION
Previously, the `element.off()` on the 'change' event was unsubscribing all 'change' handlers as `picker.change` is undefined. I believe that this should simply just be 'change' as this is the handler function used when originally observing the 'change' event.
