### PR TITLE
Use the bootstrap variable for the button active colors

### DIFF
--- a/src/less/bootstrap-datetimepicker.less
+++ b/src/less/bootstrap-datetimepicker.less
@@ -182,7 +182,7 @@
         &.active,
         &.active:hover {
             background-color: @btn-primary-bg;
-            color: #fff;
+            color: @btn-primary-color;
             text-shadow: 0 -1px 0 rgba(0,0,0,.25);
         }
 
@@ -212,7 +212,7 @@
 
             &.active {
                 background-color: @btn-primary-bg;
-                color: #fff;
+                color: @btn-primary-color;
                 text-shadow: 0 -1px 0 rgba(0,0,0,.25);
             }
 


### PR DESCRIPTION
Ran into this after modifying our bootstrap variables, expecting this to work with our new variables. But it was hardcoded to white.

This change makes it use the `btn-primary-color` variable to provide better integration with bootstrap and modifications to the bootstrap variables used with this library.
