### PR TITLE
incremented bootstrap version dependeny

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
       "moment": "~2.8.1",
       "bootstrap": "~3.1",
-      "jquery": "~1.8.3"
+      "jquery": "~1.9"
   },
   "devDependencies": {
     "grunt": "latest",


### PR DESCRIPTION
I tried 
`npm install Eonasdan/bootstrap-datetimepicker`

and got an error message 

```
npm ERR! notarget No compatible version found: bootstrap@'>=3.0.0-0 <3.1.0-0'
npm ERR! notarget Valid install targets:
npm ERR! notarget ["0.0.1","0.0.2","3.1.1","3.2.0"]
```

Changing the bootstrap dependency to ~3.1 does seem to fix that problem, but perhaps you have a preferred solution.  I'm pretty new to NPM.
