### PR TITLE
AngularJS fixing for ng-model value

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -959,6 +959,7 @@ THE SOFTWARE.
                 formatted = moment(picker.date).format(picker.format);
             }
             getPickerInput().val(formatted);
+            getPickerInput().trigger('input');
             picker.element.data('date', formatted);
             if (!picker.options.pickTime) {
                 picker.hide();


### PR DESCRIPTION
Binding a ng-model to the input of calendar, when i change the date
value by the panel, model value not change.
Adding this trigger ng-model get the new value.

This is the link to see the bug:
http://embed.plnkr.co/GJrErx/preview
