### PR TITLE
Implemented #283 - Clear button by simply putting "datepickerclear" class

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -889,6 +889,7 @@ THE SOFTWARE.
                     picker.component.on('click', $.proxy(picker.show, this));
                     picker.component.on('mousedown', $.proxy(stopEvent, this));
                 } else {
+                    picker.element.find('.datepickerclear').on('click', $.proxy(picker.clear, this));
                     picker.element.on('click', $.proxy(picker.show, this));
                 }
             }
@@ -1169,6 +1170,13 @@ THE SOFTWARE.
                 (picker.options.useSeconds ?
                     '<div class="timepicker-seconds" data-action="selectSecond"><table class="table-condensed"></table></div>' : '')
             );
+        };
+
+        picker.clear = function (e) {
+            e.stopPropagation();
+            e.preventDefault();
+
+            picker.setValue(null);
         };
 
         picker.destroy = function () {


### PR DESCRIPTION
Use clear button by simply putting "datepickerclear" class on span element. By this way, you can choose your favorite icon.
