### PR TITLE
Fix millisecond dropping bug

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -704,7 +704,8 @@ THE SOFTWARE.
                                     d: picker.viewDate.date(),
                                     h: picker.date.hours(),
                                     m: picker.date.minutes(),
-                                    s: picker.date.seconds()
+                                    s: picker.date.seconds(),
+                                    ms: picker.date.milliseconds()
                                 });
                                 set();
                                 notifyChange(oldDate, e.type);
@@ -738,7 +739,8 @@ THE SOFTWARE.
                                     d: day,
                                     h: picker.date.hours(),
                                     m: picker.date.minutes(),
-                                    s: picker.date.seconds()
+                                    s: picker.date.seconds(),
+                                    ms: picker.date.milliseconds()
                                 }
                                 );
                                 picker.viewDate = moment({


### PR DESCRIPTION
Fixes the following issue:
https://github.com/Eonasdan/bootstrap-datetimepicker/issues/582

As you can see, the millisecond values are not specified when the new Moment date object is created. I tested that this works well with a Moment.js display format which uses milliseconds.
