### PR TITLE
Fix detection of 24 hour format

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -153,7 +153,7 @@ THE SOFTWARE.
                     }
                 }
             }
-            picker.use24hours = format.search(/(h|a)([^[\]]+)(?:$|\[)/) < 0;
+            picker.use24hours = picker.format.search(/(h|a)([^[\]]+)(?:$|\[)/) < 0;
 
             if (picker.component) {
                 icon = picker.component.find('span');


### PR DESCRIPTION
Moment.js allows to escape characters by enclosing them in brackets. The expression used to determine whether to use the 24 hour format wasn't able to distinguish between escaped and unescaped characters. By using a regular expression it's possible to match the characters "h" and "a" (that signal to use the 12 hour format) only outside of brackets.
