### PR TITLE
Fix the NaN error when the minuteStepping is produce empty <td> tags.

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -827,8 +827,11 @@ THE SOFTWARE.
             },
 
             selectMinute: function (e) {
-                picker.date.minutes(parseInt($(e.target).text(), 10));
-                actions.showPicker.call(picker);
+                var value = parseInt($(e.target).text(), 10);
+                if (!isNaN(value)) {
+                    picker.date.minutes(value);
+                    actions.showPicker.call(picker);
+                }
             },
 
             selectSecond: function (e) {


### PR DESCRIPTION
If the `minuteStepping` is as such 60 minutes is not divisible by 4 without remainder (there is four columns in the table) then there are some empty cell (`<td>`) in the last row.
For example `minuteStepping` is 10 then the minute selector table is the following:

| 00 | 10 | 20 | 30 |
| --- | --- | --- | --- |
| 40 | 50 |  |  |

If you click on the empty cells then you get an `NaN` as the selected date.

![bdtpicker-nan](https://cloud.githubusercontent.com/assets/591103/4606195/bc71a838-5213-11e4-9c3c-f5c256d1c247.png)
