### PR TITLE
Fix error (Cannot read property 'append' of undefined) on chrome when build the calendar

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -466,6 +466,7 @@ THE SOFTWARE.
             }
 
             nextMonth = moment(prevMonth).add(42, 'd');
+            row = $('<tr>');
             while (prevMonth.isBefore(nextMonth)) {
                 if (prevMonth.weekday() === moment().startOf('week').weekday()) {
                     row = $('<tr>');


### PR DESCRIPTION
This error was made on the loop because the reference to the variable "row" was lost between loops.
To fix this, the variable "row" has been declared before loop.
