### PR TITLE
fix chromium undefined row error

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -493,7 +493,9 @@ THE SOFTWARE.
                         }
                     }
                 }
-                if (row) row.append('<td class="day' + clsName + '">' + prevMonth.date() + '</td>');
+                if (row) {
+                    row.append('<td class="day' + clsName + '">' + prevMonth.date() + '</td>');
+                }
 
                 currentDate = prevMonth.date();
                 prevMonth.add(1, 'd');


### PR DESCRIPTION
Chromium Version 37.0.2062.120 Ubuntu 14.04 (281580) (64-bit):

 $('#datetimepicker').datetimepicker();

Uncaught TypeError: Cannot read property 'append' of undefined bootstrap-datetimepicker.js:496
