### PR TITLE
Fill date

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1199,7 +1199,6 @@ THE SOFTWARE.
                 }
             } else if (picker.options.fillDate !== '' && getPickerInput().val() === '') {
                 var mDate = moment(picker.options.fillDate);
-                console.log(picker.options.fillDate);
                 picker.setValue(mDate.format(picker.format));
             }
 


### PR DESCRIPTION
Needed a way to set a default date that did not fill the date/time input on load, but only when the user opened the picker for the first time.
