### PR TITLE
support for non-string values of 'widgetParent' option

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -173,7 +173,7 @@ THE SOFTWARE.
             }
 
             picker.options.widgetParent =
-                typeof picker.options.widgetParent === 'string' && picker.options.widgetParent ||
+                picker.options.widgetParent ||
                 picker.element.parents().filter(function () {
                     return 'scroll' === $(this).css('overflow-y');
                 }).get(0) ||


### PR DESCRIPTION
Any jQuery target (HTML element, jQuery sets etc., not only string selectors) can be used as a value of `widgetParent` option.