### PR TITLE
BUG: 'click' can set a year to zero if the option 'widgetParent' is specified

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -629,7 +629,7 @@ THE SOFTWARE.
             e.stopPropagation();
             e.preventDefault();
             picker.unset = false;
-            var target = $(e.target).closest('span, td, th'), month, year, step, day, oldDate = moment(picker.date);
+            var target = $(e.target), month, year, step, day, oldDate = moment(picker.date);
             if (target.length === 1) {
                 if (!target.is('.disabled')) {
                     switch (target[0].nodeName.toLowerCase()) {


### PR DESCRIPTION
Steps to reproduce:
1. Set the option `widgetParent` to point to an element inside `<SPAN></SPAN>`.
2. Open a picker and try to select some text inside a calendar: move mouse while holding the button
3. Inside `click` handler `e.target` is equal to TBODY or TR.
4. `target` variable is equal to `$(e.target).closest('span, td, th')`, so it points to SPAN element which is the parent of specified `widgetParent` (see step 1)
5. `year = parseInt(target.text(), 10) || 0;` - year is equal to 0.
