### PR TITLE
v4: prevent setting an invalid date

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -60,7 +60,6 @@
                 use24hours,
                 minViewModeNumber = 0,
                 actualFormat,
-                errored = false,
                 currentViewMode,
                 datePickerModes = [
                     {
@@ -357,7 +356,7 @@
                 },
 
                 notifyEvent = function (e) {
-                    if (e.type === 'change.dp' && !errored && ((e.date && e.date.isSame(e.oldDate)) || (!e.date && !e.oldDate))) {
+                    if (e.type === 'change.dp' && ((e.date && e.date.isSame(e.oldDate)) || (!e.date && !e.oldDate))) {
                         return;
                     }
                     element.trigger(e);
@@ -657,7 +656,6 @@
                         input.val(date.format(actualFormat));
                         element.data('date', date.format(actualFormat));
                         update();
-                        errored = false;
                         unset = false;
                         notifyEvent({
                             type: 'change.dp',
@@ -665,8 +663,7 @@
                             oldDate: oldDate
                         });
                     } else {
-                        errored = true;
-                        unset = true;
+                        input.val(unset ? '' : date.format(actualFormat));
                         notifyEvent({
                             type: 'error.dp',
                             date: targetMoment
@@ -1129,7 +1126,7 @@
 
             picker.date = function (newDate) {
                 if (arguments.length === 0) {
-                    if (unset || errored) {
+                    if (unset) {
                         return null;
                     }
                     return date.clone();


### PR DESCRIPTION
If you type an invalid value (which can't be parsed) into `<INPUT/>`, the value is displayed 'as is' but `date()` returns null. This is critical with option `useStrict`, because you can input 'almost correct' value, e.g. type letter 'O' instead of digit '0' or use wrong separator. In this case the control looks good but the value is incorrect and `date()` returns null.
Demo: http://jsfiddle.net/mdnLvk87/4/  (open the browser console to see output).

I think the control should display the last valid date when an user inputs incorrect value. It's common practice for many date/time controls. So the control is also in correct state and `errored` flag is redundant.

P.S. This PR is related to https://github.com/Eonasdan/bootstrap-datetimepicker/pull/655 and based on it. I hope you'll merge both:)
