### PR TITLE
v4: don't change an icon while switching clock/calendar

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -814,9 +814,11 @@
                             } else {
                                 $this.find('span').toggleClass(options.icons.time + ' ' + options.icons.date);
                             }
-                            if (component) {
-                                component.find('span').toggleClass(options.icons.time + ' ' + options.icons.date);
-                            }
+
+                            // NOTE: uncomment if toggled state will be restored in show()
+                            //if (component) {
+                            //    component.find('span').toggleClass(options.icons.time + ' ' + options.icons.date);
+                            //}
                         }
                     },
 


### PR DESCRIPTION
An icon (on the right) is changed while switching clock/calendar. But a calendar is always shown first after `hide()/show()` and  'time' icon can confuse an user. Demo: http://jsfiddle.net/d7ssrr9q/5/

Switched state was restored in version 3, but not in version 4 now. So I just commented toggling an icon for now.
