### PR TITLE
v4: focus on open/hide on blur

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -937,7 +937,7 @@
                     widget.show();
                     place();
 
-                    if (!input.is(":focus")) {
+                    if (!input.is(':focus')) {
                         input.focus();
                     }
 


### PR DESCRIPTION
`mousedown` event on `document` hides the picker. But `mousedown` on an icon on the right isn't propagated to the `document`. So if one picker is open, click on an icon of another picker doesn't close the first. Also click on `<input />` closes already opened picker. And if you press TAB on focused `<input />` the picker will not be closed. Demo: http://jsfiddle.net/wqhgktex/3/

But if the control doesn't have an icon, `blur`event hides picker and there are no problems. I think it's good idea to apply this behavior in any case: with or without an icon. But we must guarantee that `<input/>` has focus while the picker is open. Otherwise `blur` event will never be triggered and the picker will be always open. So just force focusing `input` in method `show()`. I suppose such 'auto-focus' is useful in any case.
