### PR TITLE
v4: option extraFormats to improve parsing

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1049,6 +1049,10 @@
                     }
 
                     currentViewMode = Math.max(minViewModeNumber, currentViewMode);
+
+                    if (!unset) {
+                        setValue(date);
+                    }
                 };
 
             /********************************************************************************
@@ -1138,9 +1142,6 @@
                 options.format = newFormat;
                 if (actualFormat) {
                     initFormatting(); // reinit formatting
-                }
-                if (!unset) {
-                    setValue(date);
                 }
                 return picker;
             };


### PR DESCRIPTION
`moment` supports an array of formats to parse. I think it's a good idea to support several 'parse' formats and one 'output' format in the `datetimepicker` too. So I introduced an option `extraFormats` - an array of optional formats which can be used while parsing. `format` option specify output format and it is also used as the last parse format. Why the last? For example I want to display four-digit year but also support two-digit year. I specify the following options:

``` js
{
    format: 'DD.MM.YYYY',
    extraFormats: [ 'DD.MM.YY' ]
}
```

According to the documentation `moment` "prefers formats earlier in the array than later":

``` js
moment('1.1.1', [ 'DD.MM.YYYY', 'DD.MM.YY' ]); // 0001-01-01 - not clear
moment('1.1.1', [ 'DD.MM.YY', 'DD.MM.YYYY' ]); // 2001-01-01 - correct
```

So we must place longer formats at the end of array.
I suppose output format is typically the longest. But if someone wants to change this logic he can add `format` value into `extraFormats` at any index, e.g.:

``` js
{
    format: 'DD.MM.YYYY',
    extraFormats: [ 'DD.MM.YYYY', 'DD.MM.YY' ]
}
```

I also looked at #616: there the first element of array is always used as output format. I think it's incorrect in many cases (see example above).

P.S. Sorry for my English:)
