### PR TITLE
Removed version from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "eonasdan-bootstrap-datetimepicker",
-  "version": "3.1.3",
   "main": [
     "build/css/bootstrap-datetimepicker.min.css",
     "build/js/bootstrap-datetimepicker.min.js"


### PR DESCRIPTION
There is no need to maintain the version as `bower install` doesn't take it even in consideration since the tags are more important. When installed the `.bower.json` file will contain the version anyway.
