### PR TITLE
Readonly input property would be useful if made available

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -922,7 +922,7 @@
                             }
                         };
 
-                    if (input.prop('disabled') || input.prop('readonly') || widget) {
+                    if (input.prop('disabled') || widget) {
                         return picker;
                     }
                     if (options.useCurrent && unset) {


### PR DESCRIPTION
Disabling the input field and not showing the date picker makes sense, but the use case for allowing the readonly property is it allows for focus on the input, allows for submission of the value, but prevents the user from typing their own custom event value, and therefore conforming to chosen moment format.
