### PR TITLE
Fix custom formats and locales that dont use A

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -105,8 +105,9 @@ THE SOFTWARE.
                 }
                 picker.format += (picker.options.pickTime ? localeData.longDateFormat('LT') : '');
                 if (picker.options.useSeconds) {
-                    if (localeData.longDateFormat('LT').indexOf(' A') !== -1) {
-                        picker.format = picker.format.split(' A')[0] + ':ss A';
+                    if (localeData.longDateFormat('LT').indexOf('ss') === -1) {
+                        var minutesPos = localeData.longDateFormat('LT').indexOf('mm');
+                        picker.format = [picker.format.slice(0, minutesPos + 2), ':ss', picker.format.slice(minutesPos + 2)].join('');
                     }
                     else {
                         picker.format += ':ss';


### PR DESCRIPTION
Custom format that already include 'ss' in their formats get an additional 'ss' format appended
Also locales that dont use 'A' in their formats get the seconds just appended at the end (like german hh:mm [Uhr]:ss)
