### PR TITLE
Adds support for jquery 2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "moment": "~2.8.2",
     "bootstrap": "latest",
-    "jquery": ">=1.8.3 <2.2.0"
+    "jquery": "latest"
   },
   "devDependencies": {
     "grunt": "latest",


### PR DESCRIPTION
This patch should be useful to people who are using browserify (or other commonjs module system) who want to use this module with the newer versions of jquery
