### PR TITLE
Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "timepicker",
     "moment"
   ],
-  "dependencies": {
-    "moment": "~2.8.2",
-    "bootstrap": "latest",
-    "jquery": "latest"
+  "peerDependencies": {
+    "moment": "^2.8.2",
+    "bootstrap": "^3.3.1",
+    "jquery": ">=1.8.3 <3.0.0"
   },
   "devDependencies": {
     "grunt": "latest",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
     "timepicker",
     "moment"
   ],
+  "dependencies": {
+    "bootstrap": "^3.3.1"
+  },
   "peerDependencies": {
     "moment": "^2.8.2",
-    "bootstrap": "^3.3.1",
     "jquery": ">=1.8.3 <3.0.0"
   },
   "devDependencies": {
@@ -30,6 +32,8 @@
     "grunt-contrib-uglify": "latest",
     "grunt-jscs": "latest",
     "grunt-string-replace": "latest",
-    "load-grunt-tasks": "latest"
+    "load-grunt-tasks": "latest",
+    "moment": "^2.8.2",
+    "jquery": ">=1.8.3 <3.0.0"
   }
 }


### PR DESCRIPTION
After some test projects with this plugin, this looks like the configuration with the best compatibility.

+ Switching from `dependencies` to `peerDependencies` to avoid installing unnecessary libraries
+ Loosening restrictions on dependencies such that this is unlikely to accept an update with breaking changes, and should allow versions with the same api