### PR TITLE
Fix use24hours detection for escaped format characters

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1052,7 +1052,7 @@
                         parseFormats.push(actualFormat);
                     }
 
-                    use24hours = (actualFormat.toLowerCase().indexOf('a') < 1 && actualFormat.indexOf('h') < 1);
+                    use24hours = (actualFormat.toLowerCase().indexOf('a') < 1 && !/[^\\]h/.test(actualFormat));
 
                     if (isEnabled('y')) {
                         minViewModeNumber = 2;

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1052,7 +1052,7 @@
                         parseFormats.push(actualFormat);
                     }
 
-                    use24hours = (actualFormat.toLowerCase().indexOf('a') < 1 && !/[^\\]h/.test(actualFormat));
+                    use24hours = (actualFormat.toLowerCase().indexOf('a') < 1 && !/(^|[^\\])h/.test(actualFormat));
 
                     if (isEnabled('y')) {
                         minViewModeNumber = 2;


### PR DESCRIPTION
Escaped `h` chars in the format string should be ignored when determining if the format is asking for 24hour mode or not.

Example format that would incorrectly run in 12hour mode previously: `HH \h\r mm \m\i\n ss \s\e\c`
This correctly outputs `00 hr 00 min 00 sec` format, but the picker would still work in 12hour mode.

**TODO:** Ignore `h` chars in square bracket escape sequences, eg: `HH [sec] mm [min] ss [sec]`