### PR TITLE
Fix the options handling for components

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -289,8 +289,14 @@
             },
 
             dataToOptions = function () {
-                var eData = element.data(),
+                var eData,
                     dataOptions = {};
+
+                if (element.is('input')) {
+                    eData = element.data();
+                } else {
+                    eData = element.find('input').data();
+                }
 
                 if (eData.dateOptions && eData.dateOptions instanceof Object) {
                     dataOptions = $.extend(true, dataOptions, eData.dateOptions);


### PR DESCRIPTION
I am updating my Rails GEM to version 4. In my usecase I want to use your picker for the following markup:

```html
<div class="input-group date datepicker">
   <input id="demo_model_date_field" class="string date_picker optional form-control" type="text"
      name="demo_model[date_field]" 
      data-date-options="{"calendarWeeks":true,
          "dayViewHeaderFormat":"YYYY MMMM",
          "showTodayButton":true,  
          "widgetPositioning":{"horizontal":"left","vertical":"bottom"},
          "locale":"en"}"
   >
   <span class="input-group-btn">
      <button class="btn btn-default" type="button">
          <span class="glyphicon glyphicon-calendar"></span>
       </button>
   </span>
</div>
```
The version 3 of your picker worked with this usecase. Could you please merge this pull request.
