### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-datetimepicker",
-  "filename": "js/bootstrap-datetimepicker.min.js",
+  "main": "src/js/bootstrap-datetimepicker.js",
   "version": "4.3.5",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The "main" attribute needed by NPM fell off somewhere between 3.1.3 and 4.0.0. This restores it. I also removed 'filename' as I couldn't tell what it did at all, but I'm not that confident that I'm right there.