### PR TITLE
Fix for bootstrap-datetimepicker/848

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1011,10 +1011,6 @@
                 widget.show();
                 place();
 
-                if (!input.is(':focus')) {
-                    input.focus();
-                }
-
                 notifyEvent({
                     type: 'dp.show'
                 });


### PR DESCRIPTION
Removes automatic focusing which makes it difficult to use on mobile devices, as the keyboard pops up when clicking on the calendar icon.