### PR TITLE
Moved events to single jq namespace

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -371,7 +371,7 @@
             },
 
             notifyEvent = function (e) {
-                if (e.type === 'dp.change' && ((e.date && e.date.isSame(e.oldDate)) || (!e.date && !e.oldDate))) {
+                if (e.type === 'change.dp' && ((e.date && e.date.isSame(e.oldDate)) || (!e.date && !e.oldDate))) {
                     return;
                 }
                 element.trigger(e);
@@ -653,7 +653,7 @@
                     input.val('');
                     element.data('date', '');
                     notifyEvent({
-                        type: 'dp.change',
+                        type: 'change.dp',
                         date: null,
                         oldDate: oldDate
                     });
@@ -675,14 +675,14 @@
                     update();
                     unset = false;
                     notifyEvent({
-                        type: 'dp.change',
+                        type: 'change.dp',
                         date: date.clone(),
                         oldDate: oldDate
                     });
                 } else {
                     input.val(unset ? '' : date.format(actualFormat));
                     notifyEvent({
-                        type: 'dp.error',
+                        type: 'error.dp',
                         date: targetMoment
                     });
                 }
@@ -717,7 +717,7 @@
                 widget = false;
 
                 notifyEvent({
-                    type: 'dp.hide',
+                    type: 'hide.dp',
                     date: date.clone()
                 });
                 return picker;
@@ -957,7 +957,7 @@
                 }
 
                 notifyEvent({
-                    type: 'dp.show'
+                    type: 'show.dp'
                 });
                 return picker;
             },


### PR DESCRIPTION
There are namespaced names in docs (http://eonasdan.github.io/bootstrap-datetimepicker/Functions/) but not in the code.