### PR TITLE
Fix location of bootstrap.less

### DIFF
--- a/src/less/bootstrap-datetimepicker-build.less
+++ b/src/less/bootstrap-datetimepicker-build.less
@@ -1,5 +1,5 @@
 // Import boostrap variables including default color palette and fonts
-@import "../../node_modules/bootstrap/less/variables.less";
+@import "../../../bootstrap/less/variables.less";
 
 // Import datepicker component
 @import "_bootstrap-datetimepicker.less";


### PR DESCRIPTION
Was getting error: Error: '../../node_modules/bootstrap/less/variables.less' wasn't found. If I install with Bower there is no node_modules folder. However, there is a bootstrap in bower_components. This fixes it by modifying the import reference to the the bower_component location with a relative path.