### PR TITLE
fix #848, added option focusOnShow for disable auto focusing input field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bower_components
 node_modules
+.idea

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1016,7 +1016,7 @@
                 widget.show();
                 place();
 
-                if (!input.is(':focus')) {
+                if (options.focusOnShow && !input.is(':focus')) {
                     input.focus();
                 }
 
@@ -1760,6 +1760,19 @@
             return picker;
         };
 
+        picker.focusOnShow = function (focusOnShow) {
+            if (arguments.length === 0) {
+                return options.focusOnShow;
+            }
+
+            if (typeof focusOnShow !== 'boolean') {
+                throw new TypeError('focusOnShow() expects a boolean parameter');
+            }
+
+            options.focusOnShow = focusOnShow;
+            return picker;
+        };
+
         picker.inline = function (inline) {
             if (arguments.length === 0) {
                 return options.inline;
@@ -1935,6 +1948,7 @@
         widgetParent: null,
         ignoreReadonly: false,
         keepOpen: false,
+        focusOnShow: true,
         inline: false,
         keepInvalid: false,
         datepickerInput: '.datepickerinput',


### PR DESCRIPTION
Added option focusOnShow for disable auto focusing input field, if datetimepicker is shown. This will improve handling on mobile devices.