### PR TITLE
Unfocus input after hide

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -769,6 +769,8 @@
                 widget.remove();
                 widget = false;
 
+                element.blur();
+
                 notifyEvent({
                     type: 'dp.hide',
                     date: date.clone()


### PR DESCRIPTION
When you click close button and click again in the input the widget doesn't show because the input was still focused after hide.