### PR TITLE
Date picker does not behave properly with stepping other than 1

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -714,7 +714,9 @@
                 targetMoment = targetMoment.clone().locale(options.locale);
 
                 if (options.stepping !== 1) {
-                    targetMoment.minutes((Math.round(targetMoment.minutes() / options.stepping) * options.stepping) % 60).seconds(0);
+                    var min  = Math.ceil(targetMoment.minutes() / options.stepping) * options.stepping
+                    targetMoment.minutes(min % 60).seconds(0);
+                    targetMoment.add(Math.round(min/60), 'h');
                 }
 
                 if (isValid(targetMoment)) {


### PR DESCRIPTION
While calculating the target time, using Math.round sometimes gives a values less the current minutes.
Eg. Current Min : 44
      Min Step : 13
Math.round(44/13) = 39. The causes the widget to freeze when the time view is invokes. 
Also if the target minute spills next hour, hour has to be set properly for the target time(I'm not sure if has to show the next hour time or not tho)