### PR TITLE
Fixes missed less to sass translation

### DIFF
--- a/src/sass/_bootstrap-datetimepicker.scss
+++ b/src/sass/_bootstrap-datetimepicker.scss
@@ -118,47 +118,47 @@ $bs-datetimepicker-text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
     }
 
     .btn[data-action="incrementHours"]::after {
-        .sr-only();
+        @extend .sr-only;
         content: "Increment Hours";
     }
 
     .btn[data-action="incrementMinutes"]::after {
-        .sr-only();
+        @extend .sr-only;
         content: "Increment Minutes";
     }
 
     .btn[data-action="decrementHours"]::after {
-        .sr-only();
+        @extend .sr-only;
         content: "Decrement Hours";
     }
 
     .btn[data-action="decrementMinutes"]::after {
-        .sr-only();
+        @extend .sr-only;
         content: "Decrement Minutes";
     }
 
     .btn[data-action="showHours"]::after {
-        .sr-only();
+        @extend .sr-only;
         content: "Show Hours";
     }
 
     .btn[data-action="showMinutes"]::after {
-        .sr-only();
+        @extend .sr-only;
         content: "Show Minutes";
     }
 
     .btn[data-action="togglePeriod"]::after {
-        .sr-only();
+        @extend .sr-only;
         content: "Toggle AM/PM";
     }
 
     .btn[data-action="clear"]::after {
-        .sr-only();
+        @extend .sr-only;
         content: "Clear the picker";
     }
 
     .btn[data-action="today"]::after {
-        .sr-only();
+        @extend .sr-only;
         content: "Set the date to today";
     }
 
@@ -166,7 +166,7 @@ $bs-datetimepicker-text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
         text-align: center;
 
         &::after {
-            .sr-only();
+            @extend .sr-only;
             content: "Toggle Date and Time Screens";
         }
 
@@ -213,12 +213,12 @@ $bs-datetimepicker-text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
             }
 
             &.prev::after {
-                .sr-only();
+                @extend .sr-only;
                 content: "Previous Month";
             }
 
             &.next::after {
-                .sr-only();
+                @extend .sr-only;
                 content: "Next Month";
             }
         }

--- a/src/sass/bootstrap-datetimepicker-build.scss
+++ b/src/sass/bootstrap-datetimepicker-build.scss
@@ -1,10 +1,6 @@
 // Import bootstrap variables including default color palette and fonts
 //@import "../../node_modules/bootstrap/less/variables.less";
 
-// Import datepicker component
-@import "_bootstrap-datetimepicker";
-
-
 .sr-only {
   position: absolute;
   width: 1px;
@@ -15,3 +11,6 @@
   clip: rect(0,0,0,0);
   border: 0;
 }
+
+// Import datepicker component
+@import "_bootstrap-datetimepicker";


### PR DESCRIPTION
This fixes some missed less to sass translation (see #946).

Maybe also an idea to remove the bootstrap-datetimepicker-build.scss file and instead place the .sr-only class to the top of _bootstrap-datetimepicker.scss.