### PR TITLE
Fixed null exception for linked fields

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -704,7 +704,7 @@
                     element.data('date', '');
                     notifyEvent({
                         type: 'dp.change',
-                        date: null,
+                        date: false,
                         oldDate: oldDate
                     });
                     update();


### PR DESCRIPTION
Hey,

I ran into a bug while using linked datepickers. When linking 2 datepickers as done in the example (http://eonasdan.github.io/bootstrap-datetimepicker/#linked-pickers) the event for dp.change contains an event.date = null which then causes problems for the min and maxDate(...) functions (Uncaught TypeError: minDate() Could not parse date parameter: null).
Here's a fiddle as well: http://jsfiddle.net/8qLje5sk/

Changing the dp.change event.date for setValue(null) to false instead of null seems to fix that problem, since it is then considered in l. 1436 (for picker.minDate). If for some reason setting date = false is not ok one could just change the said line to include minDate == null.