### PR TITLE
Added option for customization parse function

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1188,10 +1188,14 @@
             },
 
             parseInputDate = function (inputDate) {
-                if (moment.isMoment(inputDate) || inputDate instanceof Date) {
-                    inputDate = moment(inputDate);
+                if (options.parseInputDate === undefined) {
+                    if (moment.isMoment(inputDate) || inputDate instanceof Date) {
+                        inputDate = moment(inputDate);
+                    } else {
+                        inputDate = moment(inputDate, parseFormats, options.useStrict);
+                    }
                 } else {
-                    inputDate = moment(inputDate, parseFormats, options.useStrict);
+                    inputDate = options.parseInputDate(inputDate);
                 }
                 inputDate.locale(options.locale);
                 return inputDate;
@@ -2070,6 +2074,20 @@
             }
 
             options.datepickerInput = datepickerInput;
+            return picker;
+        };
+
+        picker.parseInputDate = function (parseInputDate) {
+            if (arguments.length === 0) {
+                return options.parseInputDate;
+            }
+
+            if (typeof parseInputDate !== 'function') {
+                throw new TypeError('parseInputDate() sholud be as function');
+            }
+
+            options.parseInputDate = parseInputDate;
+
             return picker;
         };
 

--- a/test/publicApiSpec.js
+++ b/test/publicApiSpec.js
@@ -697,4 +697,12 @@ describe('Public API method tests', function () {
             });
         });
     });
+
+    describe('parseInputDate() function', function () {
+        describe('existence', function () {
+            it('is defined', function () {
+                expect(dtp.parseInputDate).toBeDefined();
+            });
+        });
+    });
 });


### PR DESCRIPTION
Hi! I needed to override a function that is responsible for parsing the date. For example: the user can enter 'yesterday' or '30 days ago' and it should be formatted correctly in the desired date.