### PR TITLE
.today mark fixed

### DIFF
--- a/src/less/_bootstrap-datetimepicker.less
+++ b/src/less/_bootstrap-datetimepicker.less
@@ -268,7 +268,8 @@
                 &:before {
                     content: '';
                     display: inline-block;
-                    border: 0 0 7px 7px solid transparent;
+                    border: solid transparent;
+                    border-width: 0 0 7px 7px;
                     border-bottom-color: @bs-datetimepicker-active-bg;
                     border-top-color: @bs-datetimepicker-secondary-border-color-rgba;
                     position: absolute;


### PR DESCRIPTION
``.today`` marker wasn't visible because of invalid css-syntax in border property.
- - - -
![Screenshot](https://cloud.githubusercontent.com/assets/4066435/8084751/59d217fe-0f95-11e5-84db-49f207d68c6d.png)