### PR TITLE
add default! to sass variables

### DIFF
--- a/src/sass/_bootstrap-datetimepicker.scss
+++ b/src/sass/_bootstrap-datetimepicker.scss
@@ -3,17 +3,17 @@
  * ! version : 4.7.14
  * https://github.com/Eonasdan/bootstrap-datetimepicker/
  */
-$bs-datetimepicker-timepicker-font-size: 1.2em;
-$bs-datetimepicker-active-bg: $btn-primary-bg;
-$bs-datetimepicker-active-color: $btn-primary-color;
-$bs-datetimepicker-border-radius: $border-radius-base;
-$bs-datetimepicker-btn-hover-bg: $gray-lighter;
-$bs-datetimepicker-disabled-color: $gray-light;
-$bs-datetimepicker-alternate-color: $gray-light;
-$bs-datetimepicker-secondary-border-color: #ccc;
-$bs-datetimepicker-secondary-border-color-rgba: rgba(0, 0, 0, 0.2);
-$bs-datetimepicker-primary-border-color: white;
-$bs-datetimepicker-text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+$bs-datetimepicker-timepicker-font-size: 1.2em !default;
+$bs-datetimepicker-active-bg: $btn-primary-bg !default;
+$bs-datetimepicker-active-color: $btn-primary-color !default;
+$bs-datetimepicker-border-radius: $border-radius-base !default;
+$bs-datetimepicker-btn-hover-bg: $gray-lighter !default;
+$bs-datetimepicker-disabled-color: $gray-light !default;
+$bs-datetimepicker-alternate-color: $gray-light !default;
+$bs-datetimepicker-secondary-border-color: #ccc !default;
+$bs-datetimepicker-secondary-border-color-rgba: rgba(0, 0, 0, 0.2) !default;
+$bs-datetimepicker-primary-border-color: white !default;
+$bs-datetimepicker-text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25) !default;
 
 .bootstrap-datetimepicker-widget {
     list-style: none;


### PR DESCRIPTION
Add !default to sass variables, so its possible to define the variables before the datetimepicker sass is included in the sass file.
Then the datetimepicker sass uses my own variables (if defined), and won't override it with its own.
If you don't define your own variables, the defaults from datetimepicker will be used.