### PR TITLE
DateTimePicker with timezone option

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -57,10 +57,11 @@
     }
 
     var dateTimePicker = function (element, options) {
-            if(!options.timeZone)
-                 options.timeZone = '';
+			var calendarTimeZone = '';
+			if(!options.timeZone)
+				calendarTimeZone = options.timeZone;
             var picker = {},
-            date = moment().tz(options.timeZone).startOf('d'),
+            date = moment().tz(calendarTimeZone).startOf('d'),
             viewDate = date.clone(),
             unset = true,
             input,
@@ -695,7 +696,7 @@
                     if (!isValid(currentDate, 'd')) {
                         clsName += ' disabled';
                     }
-                    if (currentDate.isSame(moment().tz(options.timeZone), 'd')) {
+                    if (currentDate.isSame(moment().tz(calendarTimeZone), 'd')) {
                         clsName += ' today';
                     }
                     if (currentDate.day() === 0 || currentDate.day() === 6) {
@@ -1101,8 +1102,8 @@
                 clear: clear,
 
                 today: function () {
-                    if (isValid(moment().tz(options.timeZone), 'd')) {
-                        setValue(moment().tz(options.timeZone));
+                    if (isValid(moment().tz(calendarTimeZone), 'd')) {
+                        setValue(moment().tz(calendarTimeZone));
                     }
                 },
 
@@ -1144,7 +1145,7 @@
                 if (input.val() !== undefined && input.val().trim().length !== 0) {
                     setValue(parseInputDate(input.val().trim()));
                 } else if (options.useCurrent && unset && ((input.is('input') && input.val().trim().length === 0) || options.inline)) {
-                    currentMoment = moment().tz(options.timeZone);
+                    currentMoment = moment().tz(calendarTimeZone);
                     if (typeof options.useCurrent === 'string') {
                         currentMoment = useCurrentGranularity[options.useCurrent](currentMoment);
                     }
@@ -1189,7 +1190,7 @@
             },
 
              parseInputDate = function (inputDate) {
-                var currentZoneOffset = moment().tz(options.timeZone).zone();
+                var currentZoneOffset = moment().tz(calendarTimeZone).zone();
                 var incomingZoneOffset = moment(inputDate).zone();
                 
                 if (moment.isMoment(inputDate) || inputDate instanceof Date) {
@@ -1199,9 +1200,9 @@
                 }
 
                 if (incomingZoneOffset != currentZoneOffset) {
-                    var timeZoneIndicator = moment().tz(options.timeZone).format('Z');
+                    var timeZoneIndicator = moment().tz(calendarTimeZone).format('Z');
                     var dateWithTimeZoneInfo = moment(inputDate).format("YYYY-MM-DD[T]HH:mm:ss") + timeZoneIndicator;
-                    inputDate = moment(dateWithTimeZoneInfo).tz(options.timeZone);
+                    inputDate = moment(dateWithTimeZoneInfo).tz(calendarTimeZone);
                 }
                 inputDate.locale(options.locale);
                 return inputDate;
@@ -1630,7 +1631,7 @@
 
             if (typeof maxDate === 'string') {
                 if (maxDate === 'now' || maxDate === 'moment') {
-                    maxDate = moment().tz(options.timeZone);
+                    maxDate = moment().tz(calendarTimeZone);
                 }
             }
 
@@ -1666,7 +1667,7 @@
 
             if (typeof minDate === 'string') {
                 if (minDate === 'now' || minDate === 'moment') {
-                    minDate = moment().tz(options.timeZone);
+                    minDate = moment().tz(calendarTimeZone);
                 }
             }
 
@@ -1708,7 +1709,7 @@
 
             if (typeof defaultDate === 'string') {
                 if (defaultDate === 'now' || defaultDate === 'moment') {
-                    defaultDate = moment().tz(options.timeZone);
+                    defaultDate = moment().tz(calendarTimeZone);
                 }
             }
 
@@ -2352,7 +2353,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment().tz(options.timeZone);
+                var d = this.date() || moment().tz(calendarTimeZone);
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().subtract(7, 'd'));
                 } else {
@@ -2364,7 +2365,7 @@
                     this.show();
                     return;
                 }
-                var d = this.date() || moment().tz(options.timeZone);
+                var d = this.date() || moment().tz(calendarTimeZone);
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().add(7, 'd'));
                 } else {
@@ -2375,7 +2376,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment().tz(options.timeZone);
+                var d = this.date() || moment().tz(calendarTimeZone);
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().subtract(1, 'y'));
                 } else {
@@ -2386,7 +2387,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment().tz(options.timeZone);
+                var d = this.date() || moment().tz(calendarTimeZone);
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().add(1, 'y'));
                 } else {
@@ -2397,7 +2398,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment().tz(options.timeZone);
+                var d = this.date() || moment().tz(calendarTimeZone);
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().subtract(1, 'd'));
                 }
@@ -2406,7 +2407,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment().tz(options.timeZone);
+                var d = this.date() || moment().tz(calendarTimeZone);
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().add(1, 'd'));
                 }
@@ -2415,7 +2416,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment().tz(options.timeZone);
+                var d = this.date() || moment().tz(calendarTimeZone);
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().subtract(1, 'M'));
                 }
@@ -2424,7 +2425,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment().tz(options.timeZone);
+                var d = this.date() || moment().tz(calendarTimeZone);
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().add(1, 'M'));
                 }
@@ -2445,7 +2446,7 @@
                 }
             },
             t: function () {
-                this.date(moment().tz(options.timeZone));
+                this.date(moment().tz(calendarTimeZone));
             },
             'delete': function () {
                 this.clear();

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -57,7 +57,9 @@
     }
 
     var dateTimePicker = function (element, options) {
-        var picker = {},
+            if(!options.timeZone)
+                 options.timeZone = '';
+            var picker = {},
             date = moment().tz(options.timeZone).startOf('d'),
             viewDate = date.clone(),
             unset = true,


### PR DESCRIPTION
Calendar works in the timezone set from options. Internally uses moment timezone.
Moment-time zone-all-years.js Is used for time zone conversion:
http://momentjs.com/downloads/moment-timezone-with-data-2010-2020.js

Example:
dateControl.datetimepicker({
timeZone: 'Asia/Kolkata'
});