### PR TITLE
Change name to match that of npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     ],
     "license": "MIT",
     "main": "src/js/bootstrap-datetimepicker.js",
-    "name": "bootstrap-datetimepicker",
+    "name": "eonasdan-bootstrap-datetimepicker",
     "repository": {
         "type": "git",
         "url": "https://github.com/eonasdan/bootstrap-datetimepicker.git"


### PR DESCRIPTION
Change name to match npm's name since the package is here: https://www.npmjs.com/package/eonasdan-bootstrap-datetimepicker