### PR TITLE
Don't exclude build/ directory from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,6 @@
 /node_modules
 /Makefile
 /test
-/build
 *.log
 *.swp
 *~


### PR DESCRIPTION
This makes it possible to use the minified files when installing from npm.
Fixes issue #1022.