### PR TITLE
Get rid of the ugly ../../node_modules in build/css/bootstrap-datetimepicker.min.css

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,13 +86,17 @@ module.exports = function (grunt) {
             production: {
                 options: {
                     cleancss: true,
-                    compress: true
+                    compress: true,
+                    paths: 'node_modules'
                 },
                 files: {
                     'build/css/bootstrap-datetimepicker.min.css': 'src/less/bootstrap-datetimepicker-build.less'
                 }
             },
             development: {
+                options: {
+                    paths: 'node_modules'
+                },
                 files: {
                     'build/css/bootstrap-datetimepicker.css': 'src/less/bootstrap-datetimepicker-build.less'
                 }

--- a/src/less/bootstrap-datetimepicker-build.less
+++ b/src/less/bootstrap-datetimepicker-build.less
@@ -1,5 +1,5 @@
 // Import bootstrap variables including default color palette and fonts
-@import "../../node_modules/bootstrap/less/variables.less";
+@import "bootstrap/less/variables.less";
 
 // Import datepicker component
 @import "_bootstrap-datetimepicker.less";


### PR DESCRIPTION
In favor of using the 'path' option of grunt-contrib-less.

When using Symfony2 and SpBowerBundle, the node_modules does not exist.
Having imports that are not tied to vendors locations allows us to compile .less files with this setup without breaking the default one for this project.