### PR TITLE
Fixed seconds overflowing the container

### DIFF
--- a/src/less/_bootstrap-datetimepicker.less
+++ b/src/less/_bootstrap-datetimepicker.less
@@ -234,7 +234,7 @@
         & td {
             height: 54px;
             line-height: 54px;
-            width: 54px;
+            width: auto;
 
             &.cw {
                 font-size: .8em;


### PR DESCRIPTION
The width should be auto as if it is set to 54px there is not enough room for the seconds.