### PR TITLE
Adding "ignorereadonly" option documentation

### DIFF
--- a/Options/index.html
+++ b/Options/index.html
@@ -205,6 +205,8 @@
             <li><a href="#viewdate">viewDate</a></li>
         
             <li><a href="#tooltips">tooltips</a></li>
+
+            <li><a href="#ignorereadonly">ignoreReadonly</a></li>
         
     
     </ul>
@@ -514,6 +516,13 @@ Accepts: string or jQuery object
 </code></pre>
 
 <p>This will change the <code>tooltips</code> over each icon to a custom string</p>
+<hr />
+<h3 id="ignorereadonly">ignoreReadOnly</h3>
+<pre><code>Default: false
+Accepts: bool
+</code></pre>
+<p>Allow date picker show event to fire even when the associated input element has the <code>readonly="readonly"</code> property </p>
+
 </div>
 			</div>
         </div>


### PR DESCRIPTION
I had the need to have a datepicker without a control button, so the only way to show the datepicker would be to click the associated input, however I also wanted the input to not be editable, but when I did that the date picker won't show up on click.

I wasn't satisfied with ugly hacks and I was about to send a patch to support this very functionality, but I noticed it was already implemented but not documented ! So here's the piece of documentation for the ```ignoreReadonly``` option.