### PR TITLE
Add ability to set time zone used by the datepicker

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -116,6 +116,7 @@ module.exports = function (grunt) {
                     vendor: [
                         'node_modules/jquery/dist/jquery.min.js',
                         'node_modules/moment/min/moment-with-locales.min.js',
+                        'node_modules/moment-timezone/moment-timezone.js',
                         'node_modules/bootstrap/dist/js/bootstrap.min.js'
                     ],
                     display: 'none',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -116,7 +116,6 @@ module.exports = function (grunt) {
                     vendor: [
                         'node_modules/jquery/dist/jquery.min.js',
                         'node_modules/moment/min/moment-with-locales.min.js',
-                        'node_modules/moment-timezone/moment-timezone.js',
                         'node_modules/bootstrap/dist/js/bootstrap.min.js'
                     ],
                     display: 'none',

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,8 @@
   ],
   "dependencies": {
     "jquery": ">=1.8.3",
-    "moment": ">=2.9.0"
+    "moment": ">=2.9.0",
+    "moment-timezone": ">=0.4.0"
   },
   "homepage": "https://github.com/Eonasdan/bootstrap-datetimepicker",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     },
     "dependencies": {
         "moment": "~2.8",
+        "moment-timezone" : "~0.4",
         "bootstrap": "^3.0",
         "jquery": ">=1.8.3 <2.2.0"
     },

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -37,9 +37,9 @@
     'use strict';
     if (typeof define === 'function' && define.amd) {
         // AMD is used - Register as an anonymous module.
-        define(['jquery', 'moment'], factory);
+        define(['jquery', 'moment', 'moment-timezone'], factory);
     } else if (typeof exports === 'object') {
-        factory(require('jquery'), require('moment'));
+        factory(require('jquery'), require('moment'), require('moment-timezone'));
     } else {
         // Neither AMD nor CommonJS used. Use global variables.
         if (typeof jQuery === 'undefined') {
@@ -58,7 +58,7 @@
 
     var dateTimePicker = function (element, options) {
         var picker = {},
-            date = moment().startOf('d'),
+            date = moment().tz(options.timeZone).startOf('d'),
             viewDate = date.clone(),
             unset = true,
             input,
@@ -699,7 +699,7 @@
                     if (!isValid(currentDate, 'd')) {
                         clsName += ' disabled';
                     }
-                    if (currentDate.isSame(moment(), 'd')) {
+                    if (currentDate.isSame(moment().tz(options.timeZone), 'd')) {
                         clsName += ' today';
                     }
                     if (currentDate.day() === 0 || currentDate.day() === 6) {
@@ -1108,8 +1108,8 @@
                 clear: clear,
 
                 today: function () {
-                    if (isValid(moment(), 'd')) {
-                        setValue(moment());
+                    if (isValid(moment().tz(options.timeZone), 'd')) {
+                        setValue(moment().tz(options.timeZone));
                     }
                 },
 
@@ -1151,7 +1151,7 @@
                 if (input.val() !== undefined && input.val().trim().length !== 0) {
                     setValue(parseInputDate(input.val().trim()));
                 } else if (options.useCurrent && unset && ((input.is('input') && input.val().trim().length === 0) || options.inline)) {
-                    currentMoment = moment();
+                    currentMoment = moment().tz(options.timeZone);
                     if (typeof options.useCurrent === 'string') {
                         currentMoment = useCurrentGranularity[options.useCurrent](currentMoment);
                     }
@@ -1200,7 +1200,7 @@
                     if (moment.isMoment(inputDate) || inputDate instanceof Date) {
                         inputDate = moment(inputDate);
                     } else {
-                        inputDate = moment(inputDate, parseFormats, options.useStrict);
+                        inputDate = moment(inputDate, parseFormats, options.useStrict).tz(options.timeZone);
                     }
                 } else {
                     inputDate = options.parseInputDate(inputDate);
@@ -1486,6 +1486,16 @@
             return picker;
         };
 
+        picker.timeZone = function (newZone) {
+            if (arguments.length === 0) {
+                return options.timeZone;
+            }
+
+            options.timeZone = newZone;
+
+            return picker;
+        };
+
         picker.dayViewHeaderFormat = function (newFormat) {
             if (arguments.length === 0) {
                 return options.dayViewHeaderFormat;
@@ -1622,7 +1632,7 @@
 
             if (typeof maxDate === 'string') {
                 if (maxDate === 'now' || maxDate === 'moment') {
-                    maxDate = moment();
+                    maxDate = moment().tz(options.timeZone);
                 }
             }
 
@@ -1658,7 +1668,7 @@
 
             if (typeof minDate === 'string') {
                 if (minDate === 'now' || minDate === 'moment') {
-                    minDate = moment();
+                    minDate = moment().tz(options.timeZone);
                 }
             }
 
@@ -1700,7 +1710,7 @@
 
             if (typeof defaultDate === 'string') {
                 if (defaultDate === 'now' || defaultDate === 'moment') {
-                    defaultDate = moment();
+                    defaultDate = moment().tz(options.timeZone);
                 }
             }
 
@@ -2312,6 +2322,7 @@
     };
 
     $.fn.datetimepicker.defaults = {
+        timeZone: 'Etc/UTC',
         format: false,
         dayViewHeaderFormat: 'MMMM YYYY',
         extraFormats: false,
@@ -2386,7 +2397,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment();
+                var d = this.date() || moment().tz(this.timeZone());
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().subtract(7, 'd'));
                 } else {
@@ -2398,7 +2409,7 @@
                     this.show();
                     return;
                 }
-                var d = this.date() || moment();
+                var d = this.date() || moment().tz(this.timeZone());
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().add(7, 'd'));
                 } else {
@@ -2409,7 +2420,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment();
+                var d = this.date() || moment().tz(this.timeZone());
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().subtract(1, 'y'));
                 } else {
@@ -2420,7 +2431,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment();
+                var d = this.date() || moment().tz(this.timeZone());
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().add(1, 'y'));
                 } else {
@@ -2431,7 +2442,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment();
+                var d = this.date() || moment().tz(this.timeZone());
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().subtract(1, 'd'));
                 }
@@ -2440,7 +2451,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment();
+                var d = this.date() || moment().tz(this.timeZone());
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().add(1, 'd'));
                 }
@@ -2449,7 +2460,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment();
+                var d = this.date() || moment().tz(this.timeZone());
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().subtract(1, 'M'));
                 }
@@ -2458,7 +2469,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment();
+                var d = this.date() || moment().tz(this.timeZone());
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().add(1, 'M'));
                 }
@@ -2479,7 +2490,7 @@
                 }
             },
             t: function () {
-                this.date(moment());
+                this.date(moment().tz(this.timeZone()));
             },
             'delete': function () {
                 this.clear();

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -37,9 +37,9 @@
     'use strict';
     if (typeof define === 'function' && define.amd) {
         // AMD is used - Register as an anonymous module.
-        define(['jquery', 'moment', 'moment-timezone'], factory);
+        define(['jquery', 'moment'], factory);
     } else if (typeof exports === 'object') {
-        factory(require('jquery'), require('moment'), require('moment-timezone'));
+        factory(require('jquery'), require('moment'));
     } else {
         // Neither AMD nor CommonJS used. Use global variables.
         if (typeof jQuery === 'undefined') {
@@ -58,8 +58,8 @@
 
     var dateTimePicker = function (element, options) {
         var picker = {},
-            date = moment().tz(options.timeZone).startOf('d'),
-            viewDate = date.clone(),
+            date,
+            viewDate,
             unset = true,
             input,
             component = false,
@@ -132,6 +132,40 @@
              * Private functions
              *
              ********************************************************************************/
+            getMoment = function (d) {
+                var tzEnabled = false,
+                    returnMoment,
+                    currentZoneOffset,
+                    incomingZoneOffset,
+                    timeZoneIndicator,
+                    dateWithTimeZoneInfo;
+
+                if (moment.tz !== undefined && options.timeZone !== undefined && options.timeZone !== null && options.timeZone !== '') {
+                    tzEnabled = true;
+                }
+                if (d === undefined || d === null) {
+                    if (tzEnabled) {
+                        returnMoment = moment().tz(options.timeZone).startOf('d');
+                    } else {
+                        returnMoment = moment().startOf('d');
+                    }
+                } else {
+                    if (tzEnabled) {
+                        currentZoneOffset = moment().tz(options.timeZone).utcOffset();
+                        incomingZoneOffset = moment(d, parseFormats, options.useStrict).utcOffset();
+                        if (incomingZoneOffset !== currentZoneOffset) {
+                            timeZoneIndicator = moment().tz(options.timeZone).format('Z');
+                            dateWithTimeZoneInfo = moment(d, parseFormats, options.useStrict).format('YYYY-MM-DD[T]HH:mm:ss') + timeZoneIndicator;
+                            returnMoment = moment(dateWithTimeZoneInfo, parseFormats, options.useStrict).tz(options.timeZone);
+                        } else {
+                            returnMoment = moment(d, parseFormats, options.useStrict).tz(options.timeZone);
+                        }
+                    } else {
+                        returnMoment = moment(d, parseFormats, options.useStrict);
+                    }
+                }
+                return returnMoment;
+            },
             isEnabled = function (granularity) {
                 if (typeof granularity !== 'string' || granularity.length > 1) {
                     throw new TypeError('isEnabled expects a single character string parameter');
@@ -699,7 +733,7 @@
                     if (!isValid(currentDate, 'd')) {
                         clsName += ' disabled';
                     }
-                    if (currentDate.isSame(moment().tz(options.timeZone), 'd')) {
+                    if (currentDate.isSame(getMoment(), 'd')) {
                         clsName += ' today';
                     }
                     if (currentDate.day() === 0 || currentDate.day() === 6) {
@@ -1108,8 +1142,9 @@
                 clear: clear,
 
                 today: function () {
-                    if (isValid(moment().tz(options.timeZone), 'd')) {
-                        setValue(moment().tz(options.timeZone));
+                    var todaysDate = getMoment();
+                    if (isValid(todaysDate, 'd')) {
+                        setValue(todaysDate);
                     }
                 },
 
@@ -1151,7 +1186,7 @@
                 if (input.val() !== undefined && input.val().trim().length !== 0) {
                     setValue(parseInputDate(input.val().trim()));
                 } else if (options.useCurrent && unset && ((input.is('input') && input.val().trim().length === 0) || options.inline)) {
-                    currentMoment = moment().tz(options.timeZone);
+                    currentMoment = getMoment();
                     if (typeof options.useCurrent === 'string') {
                         currentMoment = useCurrentGranularity[options.useCurrent](currentMoment);
                     }
@@ -1200,7 +1235,7 @@
                     if (moment.isMoment(inputDate) || inputDate instanceof Date) {
                         inputDate = moment(inputDate);
                     } else {
-                        inputDate = moment(inputDate, parseFormats, options.useStrict).tz(options.timeZone);
+                        inputDate = getMoment(inputDate);
                     }
                 } else {
                     inputDate = options.parseInputDate(inputDate);
@@ -1632,7 +1667,7 @@
 
             if (typeof maxDate === 'string') {
                 if (maxDate === 'now' || maxDate === 'moment') {
-                    maxDate = moment().tz(options.timeZone);
+                    maxDate = getMoment();
                 }
             }
 
@@ -1668,7 +1703,7 @@
 
             if (typeof minDate === 'string') {
                 if (minDate === 'now' || minDate === 'moment') {
-                    minDate = moment().tz(options.timeZone);
+                    minDate = getMoment();
                 }
             }
 
@@ -1710,7 +1745,7 @@
 
             if (typeof defaultDate === 'string') {
                 if (defaultDate === 'now' || defaultDate === 'moment') {
-                    defaultDate = moment().tz(options.timeZone);
+                    defaultDate = getMoment();
                 }
             }
 
@@ -2051,6 +2086,10 @@
             return picker;
         };
 
+        picker.getMoment = function (d) {
+            return getMoment(d);
+        };
+
         picker.debug = function (debug) {
             if (typeof debug !== 'boolean') {
                 throw new TypeError('debug() expects a boolean parameter');
@@ -2281,6 +2320,10 @@
             throw new Error('Could not initialize DateTimePicker without an input element');
         }
 
+        // Set defaults for date here now instead of in var declaration
+        date = getMoment();
+        viewDate = date.clone();
+
         $.extend(true, options, dataToOptions());
 
         picker.options(options);
@@ -2397,7 +2440,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment().tz(this.timeZone());
+                var d = this.date() || this.getMoment();
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().subtract(7, 'd'));
                 } else {
@@ -2409,7 +2452,7 @@
                     this.show();
                     return;
                 }
-                var d = this.date() || moment().tz(this.timeZone());
+                var d = this.date() || this.getMoment();
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().add(7, 'd'));
                 } else {
@@ -2420,7 +2463,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment().tz(this.timeZone());
+                var d = this.date() || this.getMoment();
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().subtract(1, 'y'));
                 } else {
@@ -2431,7 +2474,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment().tz(this.timeZone());
+                var d = this.date() || this.getMoment();
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().add(1, 'y'));
                 } else {
@@ -2442,7 +2485,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment().tz(this.timeZone());
+                var d = this.date() || this.getMoment();
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().subtract(1, 'd'));
                 }
@@ -2451,7 +2494,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment().tz(this.timeZone());
+                var d = this.date() || this.getMoment();
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().add(1, 'd'));
                 }
@@ -2460,7 +2503,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment().tz(this.timeZone());
+                var d = this.date() || this.getMoment();
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().subtract(1, 'M'));
                 }
@@ -2469,7 +2512,7 @@
                 if (!widget) {
                     return;
                 }
-                var d = this.date() || moment().tz(this.timeZone());
+                var d = this.date() || this.getMoment();
                 if (widget.find('.datepicker').is(':visible')) {
                     this.date(d.clone().add(1, 'M'));
                 }
@@ -2490,7 +2533,7 @@
                 }
             },
             t: function () {
-                this.date(moment().tz(this.timeZone()));
+                this.date(this.getMoment());
             },
             'delete': function () {
                 this.clear();

--- a/test/screen-capture/base.html
+++ b/test/screen-capture/base.html
@@ -6,6 +6,7 @@
 <script src="../../../node_modules/jquery/dist/jquery.min.js"></script>
 <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
 <script src="../../../node_modules/moment/moment.js"></script>
+<script src="../../../node_modules/moment-timezone/moment-timezone.js"></script>
 <script src="../../../src/js/bootstrap-datetimepicker.js"></script>
 <style>
 .parent{
@@ -43,7 +44,7 @@
                     <div class="inner"></div>
                 </div>
                 <br><br><br><br><br>
-                
+
                 {{{t}}}
 
                 <br><br><br><br><br>

--- a/test/screen-capture/base.html
+++ b/test/screen-capture/base.html
@@ -6,7 +6,6 @@
 <script src="../../../node_modules/jquery/dist/jquery.min.js"></script>
 <script src="../../../node_modules/bootstrap/dist/js/bootstrap.js"></script>
 <script src="../../../node_modules/moment/moment.js"></script>
-<script src="../../../node_modules/moment-timezone/moment-timezone.js"></script>
 <script src="../../../src/js/bootstrap-datetimepicker.js"></script>
 <style>
 .parent{


### PR DESCRIPTION
Incorporating the functionality of moment-timezone, added a new option
called timeZone that allows setting the time zone of the picker rather
than relying on the client time zone settings, useful for situations
where you want to display the calendar dates/times in a time zone
regardless of what time zone the client is set.

At this point not sure how this should be incorporated, especially if timezone support isn't desired since the reliance on moment-timezone.