### PR TITLE
Consistent moment version across dependency definitions and making parseInput safer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "robloach/component-installer": "*",
     "components/jquery": ">=1.9.1",
-    "moment/moment": ">=2.8"
+    "moment/moment": ">=2.9.0"
   },
   "extra": {
     "component": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "url": "https://github.com/eonasdan/bootstrap-datetimepicker/issues"
     },
     "dependencies": {
-        "moment": "~2.8",
+        "moment": ">=2.9.0",
         "moment-timezone" : "~0.4",
         "bootstrap": "^3.3",
         "jquery": ">=1.8.3 <2.2.0"

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1234,7 +1234,9 @@
 
             parseInputDate = function (inputDate) {
                 if (options.parseInputDate === undefined) {
-                    if (moment.isMoment(inputDate) || inputDate instanceof Date) {
+                    if (moment.isMoment(inputDate)) {
+                        inputDate = inputDate.clone();
+                    } else if (inputDate instanceof Date) {
                         inputDate = moment(inputDate);
                     } else {
                         inputDate = getMoment(inputDate);


### PR DESCRIPTION
Made the `moment` version on the dependency definition consistent across `bower.json`, `component.json`, `package.json` and `composer.json`

I took `component.json` as reference since that's where the moment version was last updated on release 4.13.28

I noticed this issue because my app needs moment 2.10.x and it is causing some problems because datetimepicker reconstructs moment objects passed to it with the lib version defined in the dependency.

In my particular usecase, I'm using browserify, I have moment as dependency on version 2.10.3 and the datetimepicker in 4.15.35. In that scenario, I'm seeing errors when trying to construct datetimepickers with moment objects constructed with version 2.10 passed as options, like `picker.minDate(moment())` datetimepicker will call `parseInputDate` when setting the above option (and in many other instances actually)

 `parseInputDate` can take moment objects as well, and it seems (I could be wrong) that the intention is to create a clone of that moment object since they are mutable, but cloning it with `moment(inputDate)` results in buggy behavior like the explained above, this might actually be a bug with moment's constructor method but we can also clone a moment object by calling clone on it, which should be safer since there is no assumption about the user environment when they provide a moment object as a parameter for a function or as an option.