### PR TITLE
Setting momentjs locale when making datetimepicker instance. This sol…

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -2306,8 +2306,8 @@
             if (!$this.data('DateTimePicker')) {
                 // create a private copy of the defaults object
                 options = $.extend(true, {}, $.fn.datetimepicker.defaults, options);
-                $this.data('DateTimePicker', dateTimePicker($this, options));
                 moment.locale(options.locale);
+                $this.data('DateTimePicker', dateTimePicker($this, options));
             }
         });
     };

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -2307,6 +2307,7 @@
                 // create a private copy of the defaults object
                 options = $.extend(true, {}, $.fn.datetimepicker.defaults, options);
                 $this.data('DateTimePicker', dateTimePicker($this, options));
+                moment.locale(options.locale);
             }
         });
     };


### PR DESCRIPTION
…ves the bug when you don't use en-gb as locale and moment tries to parse date time as it was in en-gb instead of the locale provided in config.