### PR TITLE
Fix position of picker when top widget position is chosen

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -472,7 +472,7 @@
 
                 widget.css({
                     top: vertical === 'top' ? 'auto' : position.top + element.outerHeight(),
-                    bottom: vertical === 'top' ? position.top + element.outerHeight() : 'auto',
+                    bottom: vertical === 'top' ? parent.outerHeight() - (parent === element ? 0 : position.top) : 'auto',
                     left: horizontal === 'left' ? (parent === element ? 0 : position.left) : 'auto',
                     right: horizontal === 'left' ? 'auto' : parent.outerWidth() - element.outerWidth() - (parent === element ? 0 : position.left)
                 });


### PR DESCRIPTION
When widgetPositioning/vertical property is set to "top", widget's bottom property is badly computed and widget is misplaced. This PR fixes the behavior.

Old behavior: http://jsfiddle.net/6v1jeyLh/3/
New behavior: http://jsfiddle.net/s3q463at/1/