### PR TITLE
Fix the `getMoment` function

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -144,11 +144,7 @@
                     tzEnabled = true;
                 }
                 if (d === undefined || d === null) {
-                    if (tzEnabled) {
-                        returnMoment = moment().tz(options.timeZone).startOf('d');
-                    } else {
-                        returnMoment = moment().startOf('d');
-                    }
+                    returnMoment = tzEnabled ? moment().tz(options.timeZone) : moment();
                 } else {
                     if (tzEnabled) {
                         currentZoneOffset = moment().tz(options.timeZone).utcOffset();


### PR DESCRIPTION
This fixes #1311.

The function trimmed newly created moments to the hole day by default
which caused problems with the `useCurrent` option. Removing
`.startOf('d') fixes the problem.