### PR TITLE
fixed timezone shift in some cases + added test case. Fixes #1326

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -103,12 +103,27 @@ module.exports = function (grunt) {
             }
         },
 
+        env: {
+            paris: {
+                TZ : 'Europe/Paris' // sets env for phantomJS https://github.com/ariya/phantomjs/issues/10379#issuecomment-36058589
+            }
+        },
+
+        connect: {
+            server: {
+                options: {
+                    port: 8099
+                }
+            }
+        },
+
         jasmine: {
             customTemplate: {
                 src: 'src/js/*.js',
                 options: {
                     specs: 'test/*Spec.js',
                     helpers: 'test/*Helper.js',
+                    host: 'http://127.0.0.1:8099',
                     styles: [
                         'node_modules/bootstrap/dist/css/bootstrap.min.css',
                         'build/css/bootstrap-datetimepicker.min.css'
@@ -116,6 +131,7 @@ module.exports = function (grunt) {
                     vendor: [
                         'node_modules/jquery/dist/jquery.min.js',
                         'node_modules/moment/min/moment-with-locales.min.js',
+                        'node_modules/moment-timezone/moment-timezone.js',
                         'node_modules/bootstrap/dist/js/bootstrap.min.js'
                     ],
                     display: 'none',
@@ -144,6 +160,8 @@ module.exports = function (grunt) {
 
     grunt.loadTasks('tasks');
 
+    grunt.loadNpmTasks('grunt-env');
+    grunt.loadNpmTasks('grunt-contrib-connect');
     grunt.loadNpmTasks('grunt-contrib-jasmine');
     grunt.loadNpmTasks('grunt-nuget');
 
@@ -151,7 +169,7 @@ module.exports = function (grunt) {
     require('load-grunt-tasks')(grunt);
 
     // Default task.
-    grunt.registerTask('default', ['jshint', 'jscs', 'less', 'jasmine']);
+    grunt.registerTask('default', ['jshint', 'jscs', 'less', 'env:paris', 'connect', 'jasmine']);
 
     // travis build task
     grunt.registerTask('build:travis', [
@@ -160,7 +178,7 @@ module.exports = function (grunt) {
         // build
         'uglify', 'less',
         // tests
-        'jasmine'
+        'env:paris', 'connect', 'jasmine'
     ]);
 
     // Task to be run when building
@@ -168,7 +186,7 @@ module.exports = function (grunt) {
         'jshint', 'jscs', 'uglify', 'less'
     ]);
 
-    grunt.registerTask('test', ['jshint', 'jscs', 'uglify', 'less', 'jasmine']);
+    grunt.registerTask('test', ['jshint', 'jscs', 'uglify', 'less', 'env:paris', 'connect', 'jasmine']);
 
     grunt.registerTask('docs', 'Generate docs', function () {
         grunt.util.spawn({

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
     "url": "https://github.com/eonasdan/bootstrap-datetimepicker/issues"
   },
   "dependencies": {
-    "moment": "~2.10.5",
     "bootstrap": "^3.3",
-    "jquery": ">=1.8.3 <2.2.0"
+    "jquery": ">=1.8.3 <2.2.0",
+    "moment": "~2.10.5",
+    "moment-timezone": "^0.4.0"
   },
   "description": "A date/time picker component designed to work with Bootstrap 3 and Momentjs. For usage, installation and demos see Project Site on GitHub",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,42 +1,44 @@
 {
-    "author": {
-        "name": "Jonathan Peterson"
-    },
-    "bugs": {
-        "url": "https://github.com/eonasdan/bootstrap-datetimepicker/issues"
-    },
-    "dependencies": {
-        "moment": "~2.10.5",
-        "bootstrap": "^3.3",
-        "jquery": ">=1.8.3 <2.2.0"
-    },
-    "description": "A date/time picker component designed to work with Bootstrap 3 and Momentjs. For usage, installation and demos see Project Site on GitHub",
-    "devDependencies": {
-        "grunt": "latest",
-        "grunt-contrib-jasmine": "^0.7.0",
-        "grunt-contrib-jshint": "latest",
-        "grunt-contrib-less": "latest",
-        "grunt-contrib-uglify": "latest",
-        "grunt-jscs": "latest",
-        "grunt-string-replace": "latest",
-        "load-grunt-tasks": "latest",
-        "grunt-nuget": "^0.1.4"
-    },
-    "homepage": "http://eonasdan.github.io/bootstrap-datetimepicker/",
-    "keywords": [
-        "twitter-bootstrap",
-        "bootstrap",
-        "datepicker",
-        "datetimepicker",
-        "timepicker",
-        "moment"
-    ],
-    "license": "MIT",
-    "main": "src/js/bootstrap-datetimepicker.js",
-    "name": "eonasdan-bootstrap-datetimepicker",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/eonasdan/bootstrap-datetimepicker.git"
-    },
-    "version": "4.17.42"
+  "author": {
+    "name": "Jonathan Peterson"
+  },
+  "bugs": {
+    "url": "https://github.com/eonasdan/bootstrap-datetimepicker/issues"
+  },
+  "dependencies": {
+    "moment": "~2.10.5",
+    "bootstrap": "^3.3",
+    "jquery": ">=1.8.3 <2.2.0"
+  },
+  "description": "A date/time picker component designed to work with Bootstrap 3 and Momentjs. For usage, installation and demos see Project Site on GitHub",
+  "devDependencies": {
+    "grunt": "latest",
+    "grunt-contrib-connect": "^0.11.2",
+    "grunt-contrib-jasmine": "^0.7.0",
+    "grunt-contrib-jshint": "latest",
+    "grunt-contrib-less": "latest",
+    "grunt-contrib-uglify": "latest",
+    "grunt-env": "^0.4.4",
+    "grunt-jscs": "latest",
+    "grunt-nuget": "^0.1.4",
+    "grunt-string-replace": "latest",
+    "load-grunt-tasks": "latest"
+  },
+  "homepage": "http://eonasdan.github.io/bootstrap-datetimepicker/",
+  "keywords": [
+    "twitter-bootstrap",
+    "bootstrap",
+    "datepicker",
+    "datetimepicker",
+    "timepicker",
+    "moment"
+  ],
+  "license": "MIT",
+  "main": "src/js/bootstrap-datetimepicker.js",
+  "name": "eonasdan-bootstrap-datetimepicker",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eonasdan/bootstrap-datetimepicker.git"
+  },
+  "version": "4.17.42"
 }

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -133,37 +133,18 @@
              *
              ********************************************************************************/
             getMoment = function (d) {
-                var tzEnabled = false,
-                    returnMoment,
-                    currentZoneOffset,
-                    incomingZoneOffset,
-                    timeZoneIndicator,
-                    dateWithTimeZoneInfo;
+                var returnMoment;
 
-                if (moment.tz !== undefined && options.timeZone !== undefined && options.timeZone !== null && options.timeZone !== '') {
-                    tzEnabled = true;
-                }
                 if (d === undefined || d === null) {
-                    if (tzEnabled) {
-                        returnMoment = moment().tz(options.timeZone);
-                    } else {
-                        returnMoment = moment(); //TODO should this use format? and locale?
-                    }
+                    returnMoment = moment(); //TODO should this use format? and locale?
                 } else {
-                    if (tzEnabled) {
-                        currentZoneOffset = moment().tz(options.timeZone).utcOffset();
-                        incomingZoneOffset = moment(d, parseFormats, options.useStrict).utcOffset();
-                        if (incomingZoneOffset !== currentZoneOffset) {
-                            timeZoneIndicator = moment().tz(options.timeZone).format('Z');
-                            dateWithTimeZoneInfo = moment(d, parseFormats, options.useStrict).format('YYYY-MM-DD[T]HH:mm:ss') + timeZoneIndicator;
-                            returnMoment = moment(dateWithTimeZoneInfo, parseFormats, options.useStrict).tz(options.timeZone);
-                        } else {
-                            returnMoment = moment(d, parseFormats, options.useStrict).tz(options.timeZone);
-                        }
-                    } else {
-                        returnMoment = moment(d, parseFormats, options.useStrict);
-                    }
+                    returnMoment = moment(d, parseFormats, options.useStrict);
                 }
+
+                if (hasTimeZone()) {
+                    returnMoment.tz(options.timeZone);
+                }
+
                 return returnMoment;
             },
 
@@ -192,6 +173,10 @@
 
             hasTime = function () {
                 return (isEnabled('h') || isEnabled('m') || isEnabled('s'));
+            },
+
+            hasTimeZone = function () {
+                return moment.tz !== undefined && options.timeZone !== undefined && options.timeZone !== null && options.timeZone !== '';
             },
 
             hasDate = function () {
@@ -864,6 +849,10 @@
                 }
 
                 targetMoment = targetMoment.clone().locale(options.locale);
+
+                if (hasTimeZone()) {
+                    targetMoment.tz(options.timeZone);
+                }
 
                 if (options.stepping !== 1) {
                     targetMoment.minutes((Math.round(targetMoment.minutes() / options.stepping) * options.stepping) % 60).seconds(0);

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -462,7 +462,7 @@
 
                 widget.css({
                     top: vertical === 'top' ? 'auto' : position.top + element.outerHeight(),
-                    bottom: vertical === 'top' ? position.top + element.outerHeight() : 'auto',
+                    bottom: vertical === 'top' ? parent.outerHeight() - (parent === element ? 0 : position.top) : 'auto',
                     left: horizontal === 'left' ? (parent === element ? 0 : position.left) : 'auto',
                     right: horizontal === 'left' ? 'auto' : parent.outerWidth() - element.outerWidth() - (parent === element ? 0 : position.left)
                 });

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -137,6 +137,9 @@
 
                 if (d === undefined || d === null) {
                     returnMoment = moment(); //TODO should this use format? and locale?
+                } else if (hasTimeZone()) { // There is a string to parse and a default time zone
+                    // parse with the tz function which takes a default time zone if it is not in the format string
+                    returnMoment = moment.tz(d, parseFormats, options.useStrict, options.timeZone);
                 } else {
                     returnMoment = moment(d, parseFormats, options.useStrict);
                 }

--- a/test/publicApiSpec.js
+++ b/test/publicApiSpec.js
@@ -705,4 +705,29 @@ describe('Public API method tests', function () {
             });
         });
     });
+
+    describe('Time zone tests', function () {
+        var oldTimeZone, oldFormat;
+        beforeEach(function () {
+            oldTimeZone = dtp.timeZone();
+            oldFormat = dtp.format();
+            dtp.timeZone('UTC');
+            dtp.format('YYYY-MM-DD HH:mm:ss Z');
+        });
+
+        afterEach(function () {
+            dtp.timeZone(oldTimeZone);
+            dtp.format(oldFormat);
+        });
+
+        it('should not change the value that was set', function () { // #1326
+            var now = moment().startOf('second');
+            dtp.date(now);
+            dpChangeSpy.calls.reset();
+            dtp.show();
+            dtp.hide();
+            expect(dpChangeSpy).not.toHaveBeenCalled();
+            expect(dtp.date().format()).toEqual(now.tz('UTC').format());
+        });
+    });
 });

--- a/test/publicApiSpec.js
+++ b/test/publicApiSpec.js
@@ -707,27 +707,30 @@ describe('Public API method tests', function () {
     });
 
     describe('Time zone tests', function () {
-        var oldTimeZone, oldFormat;
-        beforeEach(function () {
-            oldTimeZone = dtp.timeZone();
-            oldFormat = dtp.format();
-            dtp.timeZone('UTC');
-            dtp.format('YYYY-MM-DD HH:mm:ss Z');
-        });
+        function makeFormatTest (format, displayTimeZone) {
+            it('should not change the value that was set when using format ' + format, function () { // #1326
+                var oldFormat = dtp.format(),
+                    oldTimeZone = dtp.timeZone(),
+                    now = moment().startOf('second');
 
-        afterEach(function () {
-            dtp.timeZone(oldTimeZone);
-            dtp.format(oldFormat);
-        });
+                dtp.timeZone(displayTimeZone);
+                dtp.format(format);
 
-        it('should not change the value that was set', function () { // #1326
-            var now = moment().startOf('second');
-            dtp.date(now);
-            dpChangeSpy.calls.reset();
-            dtp.show();
-            dtp.hide();
-            expect(dpChangeSpy).not.toHaveBeenCalled();
-            expect(dtp.date().format()).toEqual(now.tz('UTC').format());
-        });
+                dtp.date(now);
+                dpChangeSpy.calls.reset();
+                dtp.show();
+                dtp.hide();
+                expect(dpChangeSpy).not.toHaveBeenCalled();
+                expect(dtp.date().format()).toEqual(now.tz(displayTimeZone).format());
+
+                dtp.format(oldFormat);
+                dtp.timeZone(oldTimeZone);
+            });
+        }
+
+        makeFormatTest('YYYY-MM-DD HH:mm:ss Z', 'UTC');
+        makeFormatTest('YYYY-MM-DD HH:mm:ss', 'UTC');
+        makeFormatTest('YYYY-MM-DD HH:mm:ss Z', 'America/New_York');
+        makeFormatTest('YYYY-MM-DD HH:mm:ss', 'America/New_York');
     });
 });

--- a/test/timezoneDataHelper.js
+++ b/test/timezoneDataHelper.js
@@ -1,0 +1,11 @@
+(function () {
+    'use strict';
+    $.ajax('node_modules/moment-timezone/data/packed/latest.json', {
+        success: function (data) {
+            moment.tz.load(data);
+        },
+        method: 'GET',
+        dataType: 'json',
+        async: false
+    });
+}());


### PR DESCRIPTION
- Removed the before/after timezone check in `getMoment()` and always apply `.tz()` #1326 
- Simplified the code in `getMoment()`
- Created a `hasTimeZone()` private function
- `setValue` now sets the timezone on the given moment to display the date in the given `options.timeZone`

Test case:
- Added a dependency on `grunt-contrib-connect` : the jasmine tests are now hosted on a temporary local web server in order to be able to load the `moment-timezone`'s JSON data file.
- Added a dependency on `grunt-env` : Lets me choose the time zone used by PhantomJS for the jasmine tests.
- Added a test case for the bug #1326