### PR TITLE
Fix bug in disabledTimeIntervals

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -569,8 +569,10 @@
                 if (options.disabledTimeIntervals && (granularity === 'h' || granularity === 'm' || granularity === 's')) {
                     var found = false;
                     $.each(options.disabledTimeIntervals, function () {
-                        if (targetMoment.isBetween(this[0], this[1])) {
-                            found = true;
+                        var a = targetMoment.clone(),
+                            b = targetMoment.clone().add(1, granularity);
+                        found = this[0] < a && b <= this[1];
+                        if (found) {
                             return false;
                         }
                     });


### PR DESCRIPTION
This commit fixes issue #1343.

The `disabledTimeIntervals` option was disabling full hours even if there was selectable minute intervals in those. Ex:

```
disabledTimeIntervals: [
    [moment('2015-09-25 17:50'), moment('2015-09-25 18:50')],
]
```

The above configuration would disable hour 18, even though the minutes between 18:50 and 18:55 should be selectable. The interval now is properly disabled.

It's important to note the disabled interval has to be open. Otherwise scheduling applications of this feature would be challenging. This means an interval 18:00 to 19:00 would allow the user to select the times 18:00 and 19:00 but nothing in between.
