### PR TITLE
Add custom validation logic

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -541,6 +541,9 @@
                 if (!targetMoment.isValid()) {
                     return false;
                 }
+                if (options.validator && options.validatorFor.indexOf(granularity) >= 0) {
+                    return options.validator(targetMoment, granularity);
+                }
                 if (options.disabledDates && granularity === 'd' && isInDisabledDates(targetMoment)) {
                     return false;
                 }
@@ -2193,6 +2196,39 @@
             return picker;
         };
 
+        picker.validator = function(validator) {
+            if (arguments.length === 0) {
+                return (options.validator ? $.extend({}, options.validator) : options.validator);
+            }
+            if (!validator) {
+                options.validator = false;
+                update();
+                return picker;
+            }
+            var isFunction = function(obj) {
+              return !!(obj && obj.constructor && obj.call && obj.apply);
+            };
+            if (!(isFunction(validator))) {
+                throw new TypeError('validator() expects a function parameter');
+            }
+            options.validator = validator;
+            update();
+            return picker;
+        };
+
+        picker.validatorFor = function (validatorFor) {
+            if (arguments.length === 0) {
+                return options.validatorFor;
+            }
+
+            if (typeof validatorFor !== 'string') {
+                throw new TypeError('validatorFor() expects a string parameter');
+            }
+
+            options.validatorFor = validatorFor;
+            return picker;
+        };
+
         picker.disabledHours = function (hours) {
             ///<signature helpKeyword="$.fn.datetimepicker.disabledHours">
             ///<summary>Returns an array with the currently set disabled hours on the component.</summary>
@@ -2547,6 +2583,8 @@
         disabledTimeIntervals: false,
         disabledHours: false,
         enabledHours: false,
+        validator: false,
+        validatorFor: 'dhms',
         viewDate: false
     };
 }));


### PR DESCRIPTION
Thanks for the awesome library!

I needed a custom validation using https://github.com/AMDmi3/opening_hours.js, to be able to control in detail what date/times are allowed. I know there are `daysOfWeekDisabled`, `disabledTimeIntervals` and `enabledHours`, but these don't allow the flexible combinations needed for my purpose. The opening_hours library does a good job at that. All in all I can do the following now:

```
  var options {
    validator: function(m, granularity) {
      var oh = new opening_hours('Mo,Tu,We,Th,Fr 8:00-23:00');
      var v;
      if (granularity == 'd') {
        var from = moment(m).startOf('day').toDate();
        var to = moment(m).endOf('day').toDate();
        v = oh.getOpenDuration(from, to) > 0;
      } else {
        v = oh.getState(moment(m).toDate());
      }
      return v;
    }
  };
  $('.datetimepicker').datetimepicker(options);
```

The code allows for a `validator` to be set, but also the granularity supported by the validator through `validatorFor`.

I hope you will consider adding this to the library .