### PR TITLE
Fix for Moment deprecation warning

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1755,6 +1755,8 @@
                 return picker;
             }
 
+            initFormatting();
+
             if (typeof defaultDate === 'string') {
                 if (defaultDate === 'now' || defaultDate === 'moment') {
                     defaultDate = getMoment();


### PR DESCRIPTION
[Moment deprecated](https://github.com/moment/moment/issues/1407) calling `moment()` without formatting information, and the defaultDate setup was calling `getMoment()` without ever having fired `initFormatting()`. This threw an ugly deprecation warning in the console from Moment.

An example can be seen at this [jsFiddle: https://jsfiddle.net/gcnzb1vj/](https://jsfiddle.net/gcnzb1vj/)

This fix will trigger `initFormatting()` before trying to call `getMoment()` as part of the default date setup.
