### PR TITLE
<fix ie8  event 'mousedown' can not prevent focus >  Update bootstrap-datetimepicker.js

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1210,7 +1210,10 @@
                 $(window).on('resize', place);
                 widget.on('click', '[data-action]', doAction); // this handles clicks on the widget
                 //widget.on('mousedown', false); //can not work under ie8
-                widget.on('mousedown', function(e){e.target.unselectable = true; return false;});
+                widget.on('mousedown', function(e){
+                 e.target.unselectable = true; 
+                 return false;
+                });
 
                 if (component && component.hasClass('btn')) {
                     component.toggleClass('active');

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1209,7 +1209,8 @@
 
                 $(window).on('resize', place);
                 widget.on('click', '[data-action]', doAction); // this handles clicks on the widget
-                widget.on('mousedown', false);
+                //widget.on('mousedown', false); //can not work under ie8
+                widget.on('mousedown', function(e){e.target.unselectable = true; return false;});
 
                 if (component && component.hasClass('btn')) {
                     component.toggleClass('active');


### PR DESCRIPTION
fix ie8  event 'mousedown' can not prevent focus 