### PR TITLE
Fixed bug where value was an hour off with stepping enabled

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -862,7 +862,11 @@
                 targetMoment = targetMoment.clone().locale(options.locale);
 
                 if (options.stepping !== 1) {
-                    targetMoment.minutes((Math.round(targetMoment.minutes() / options.stepping) * options.stepping) % 60).seconds(0);
+                	var minutes = Math.round(targetMoment.minutes() / options.stepping) * options.stepping
+                    targetMoment.minutes(minutes % 60).seconds(0);
+                    if (minutes >= 60){
+                    	targetMoment.add(1, 'h');
+                    }
                 }
 
                 if (isValid(targetMoment)) {

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -862,7 +862,7 @@
                 targetMoment = targetMoment.clone().locale(options.locale);
 
                 if (options.stepping !== 1) {
-                	var minutes = Math.round(targetMoment.minutes() / options.stepping) * options.stepping
+                	var minutes = Math.round(targetMoment.minutes() / options.stepping) * options.stepping;
                     targetMoment.minutes(minutes % 60).seconds(0);
                     if (minutes >= 60){
                     	targetMoment.add(1, 'h');

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -843,7 +843,7 @@
             },
 
             setValue = function (targetMoment) {
-                var oldDate = unset ? null : date;
+                var oldDate = unset ? null : date, roundedMinutes;
 
                 // case of calling setValue(null or false)
                 if (!targetMoment) {
@@ -862,10 +862,10 @@
                 targetMoment = targetMoment.clone().locale(options.locale);
 
                 if (options.stepping !== 1) {
-                	var minutes = Math.round(targetMoment.minutes() / options.stepping) * options.stepping;
-                    targetMoment.minutes(minutes % 60).seconds(0);
-                    if (minutes >= 60){
-                    	targetMoment.add(1, 'h');
+                    roundedMinutes = Math.round(targetMoment.minutes() / options.stepping) * options.stepping;
+                    targetMoment.minutes(roundedMinutes % 60).seconds(0);
+                    if (roundedMinutes >= 60) {
+                        targetMoment.add(1, 'h');
                     }
                 }
 


### PR DESCRIPTION
setValue(targetMoment) rounds the value using the stepping option, when the rounded minutes were 60 or more the code did not increase the hours.