### PR TITLE
Don't trim the minutes overflow when rounding in #setValue(value)

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -864,7 +864,7 @@
                 }
 
                 if (options.stepping !== 1) {
-                    targetMoment.minutes((Math.round(targetMoment.minutes() / options.stepping) * options.stepping) % 60).seconds(0);
+                    targetMoment.minutes((Math.round(targetMoment.minutes() / options.stepping) * options.stepping)).seconds(0);
                 }
 
                 if (isValid(targetMoment)) {


### PR DESCRIPTION
setValue(targetMoment) trimmed the excess minutes when rounding using stepping. This caused an hour offset when rounding up to or over 60 minutes, see this JSFiddle:
http://jsfiddle.net/gjcwzpgp/

Removing the trimming was enough, momentJS bubbles up the hour if necessary.