### PR TITLE
Use placeholder value as defaultDate

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1205,6 +1205,8 @@
                 }
                 if (input.val() !== undefined && input.val().trim().length !== 0) {
                     setValue(parseInputDate(input.val().trim()));
+                } else if (input.attr('placeholder') !== undefined && input.attr('placeholder').trim().length !== 0) {
+                    setValue(parseInputDate(input.attr('placeholder').trim()));
                 } else if (options.useCurrent && unset && (options.inline || (input.is('input') && input.val().trim().length === 0))) {
                     currentMoment = getMoment();
                     if (typeof options.useCurrent === 'string') {


### PR DESCRIPTION
If input.attr('placeholder') is set, use this value as default like input.val().
I think it will be very useful in case that set default date without input's default.
