### PR TITLE
Provide oldDate (previous value) on dp.error event

### DIFF
--- a/docs/Events.md
+++ b/docs/Events.md
@@ -68,6 +68,7 @@ Parameters:
 ```
 e = {
     date //the invalid date. Type: moment object (clone)
+    oldDate //previous date. Type: moment object (clone) or false in the event of a null
 }
 ```
 

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -885,7 +885,8 @@
                     }
                     notifyEvent({
                         type: 'dp.error',
-                        date: targetMoment
+                        date: targetMoment,
+                        oldDate: oldDate
                     });
                 }
             },


### PR DESCRIPTION
Provide oldDate (previous value) on dp.error event.  Useful if keepInvalid=true because the previous value would otherwise have been lost.

Use case:
Set keepInvalid=true then only allow certain words to be saved, otherwise revert value back to original date.
Developer wishes to allow dates or specific words such as *Present*. For example, when filling out a job history form, the most recent job may be the current job therefore an *End Date* does not make sense but the word *Present* does.

Justification:
It would be ideal if the dp.change event fired on invalid entries (when keepInvalid=true) but it doesn't hurt to include the oldDate here.