### PR TITLE
Fire dp change on invalid entry if keep invalid is true

### DIFF
--- a/docs/Events.md
+++ b/docs/Events.md
@@ -37,7 +37,7 @@ Emitted from:
 
 ### dp.change
 
-Fired when the date is changed.
+Fired when the date is changed, including when changed to a non-date (e.g. When keepInvalid=true).
 
 Parameters:
 

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -883,12 +883,12 @@
                     if (!options.keepInvalid) {
                         input.val(unset ? '' : date.format(actualFormat));
                     } else {
-						notifyEvent({
-							type: 'dp.change',
-							date: targetMoment,
-							oldDate: oldDate
-						});
-					}
+                        notifyEvent({
+                            type: 'dp.change',
+                            date: targetMoment,
+                            oldDate: oldDate
+                        });
+                    }
                     notifyEvent({
                         type: 'dp.error',
                         date: targetMoment

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -882,7 +882,13 @@
                 } else {
                     if (!options.keepInvalid) {
                         input.val(unset ? '' : date.format(actualFormat));
-                    }
+                    } else {
+						notifyEvent({
+							type: 'dp.change',
+							date: targetMoment,
+							oldDate: oldDate
+						});
+					}
                     notifyEvent({
                         type: 'dp.error',
                         date: targetMoment


### PR DESCRIPTION
Now that keepInvalid is possible it is also possible that an invalid entry causes a *change*.

Use case:
Developer sets keepInvalid=true and wishes to revert date back to previous value based the invalid entry.

Justification:
When keepInvalid=true an actual change occurs to the value which implies that a dp.change event should be fired.