### PR TITLE
Fix mouse events in old IE browsers.

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -924,7 +924,7 @@
 
                 $(window).off('resize', place);
                 widget.off('click', '[data-action]');
-                widget.off('mousedown', false);
+                widget.off('mousedown', mousedown);
 
                 widget.remove();
                 widget = false;
@@ -1233,7 +1233,7 @@
 
                 $(window).on('resize', place);
                 widget.on('click', '[data-action]', doAction); // this handles clicks on the widget
-                widget.on('mousedown', false);
+                widget.on('mousedown', mousedown);
 
                 if (component && component.hasClass('btn')) {
                     component.toggleClass('active');
@@ -1319,6 +1319,11 @@
                 return false;
             },
 
+            mousedown = function (e) {
+                e.target.unselectable = true; // disable blur event in old IE browsers
+                return false;
+            },
+
             attachDatePickerElementEvents = function () {
                 input.on({
                     'change': change,
@@ -1334,7 +1339,7 @@
                     });
                 } else if (component) {
                     component.on('click', toggle);
-                    component.on('mousedown', false);
+                    component.on('mousedown', mousedown);
                 }
             },
 
@@ -1353,7 +1358,7 @@
                     });
                 } else if (component) {
                     component.off('click', toggle);
-                    component.off('mousedown', false);
+                    component.off('mousedown', mousedown);
                 }
             },
 


### PR DESCRIPTION
Currently datetimepicker is not working correctly in IE8. A click on any widget element closes the widget without updating date value. The issue is mentioned here: http://eonasdan.github.io/bootstrap-datetimepicker/Extras/#ie-7

The widget closes because of a blur event generated for the input field. I disable this blur event.

This JSFiddle can be used as an example: http://jsfiddle.net/0785htae/1/ It Contains the libraries needed for IE8.
