### PR TITLE
Clean method invocation

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -2376,6 +2376,7 @@
         options = options || {};
 
         var args = Array.prototype.slice.call(arguments, 1),
+            isInstance = true,
             thisMethods = ['destroy', 'hide', 'show', 'toggle'],
             returnValue;
 
@@ -2391,17 +2392,16 @@
         } else if (typeof options === 'string') {
             this.each(function () {
                 var $this = $(this),
-                    instance = $this.data('DateTimePicker'),
-                    result;
+                    instance = $this.data('DateTimePicker');
                 if (!instance) {
-                    throw new Error('The bootstrap-datetimepicker("' + options + '") method was called on an element that is not using DateTimePicker');
+                    throw new Error('bootstrap-datetimepicker("' + options + '") method was called on an element that is not using DateTimePicker');
                 }
 
-                result = instance[options].apply(instance, args);
-                returnValue = result === instance ? this : result;
+                returnValue = instance[options].apply(instance, args);
+                isInstance = returnValue === instance;
             });
 
-            if ($.inArray(options, thisMethods) > -1) {
+            if (isInstance || $.inArray(options, thisMethods) > -1) {
                 return this;
             }
 

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -2373,14 +2373,42 @@
      ********************************************************************************/
 
     $.fn.datetimepicker = function (options) {
-        return this.each(function () {
-            var $this = $(this);
-            if (!$this.data('DateTimePicker')) {
-                // create a private copy of the defaults object
-                options = $.extend(true, {}, $.fn.datetimepicker.defaults, options);
-                $this.data('DateTimePicker', dateTimePicker($this, options));
+        options = options || {};
+
+        var args = Array.prototype.slice.call(arguments, 1),
+            thisMethods = ['destroy', 'hide', 'show', 'toggle'],
+            returnValue;
+
+        if (typeof options === 'object') {
+            return this.each(function () {
+                var $this = $(this);
+                if (!$this.data('DateTimePicker')) {
+                    // create a private copy of the defaults object
+                    options = $.extend(true, {}, $.fn.datetimepicker.defaults, options);
+                    $this.data('DateTimePicker', dateTimePicker($this, options));
+                }
+            });
+        } else if (typeof options === 'string') {
+            this.each(function () {
+                var $this = $(this),
+                    instance = $this.data('DateTimePicker'),
+                    result;
+                if (!instance) {
+                    throw new Error('The bootstrap-datetimepicker("' + options + '") method was called on an element that is not using DateTimePicker');
+                }
+
+                result = instance[options].apply(instance, args);
+                returnValue = result === instance ? this : result;
+            });
+
+            if ($.inArray(options, thisMethods) > -1) {
+                return this;
             }
-        });
+
+            return returnValue;
+        }
+
+        throw new TypeError('Invalid arguments for DateTimePicker: ' + options);
     };
 
     $.fn.datetimepicker.defaults = {

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -2101,6 +2101,10 @@
         };
 
         picker.keyBinds = function (keyBinds) {
+            if (arguments.length === 0) {
+                return options.keyBinds;
+            }
+
             options.keyBinds = keyBinds;
             return picker;
         };

--- a/test/publicApiSpec.js
+++ b/test/publicApiSpec.js
@@ -8,14 +8,40 @@ describe('Plugin initialization and component basic construction', function () {
     });
 
     it('creates the component with default options on an input element', function () {
-        var dtp = $('<input>');
-        $(document).find('body').append(dtp);
+        var dtpElement = $('<input>'),
+            dtp;
+        $(document).find('body').append(dtpElement);
 
         expect(function () {
-            dtp = dtp.datetimepicker();
+            expect(dtpElement.datetimepicker()).toBe(dtpElement);
         }).not.toThrow();
 
+        dtp = dtpElement.data('DateTimePicker');
+        expect(dtpElement).not.toBe(null);
+    });
+
+    it('creates the component with default options merged with those provided on an input element', function () {
+        var options = {locale: 'fr'},
+            dtpElement = $('<input>'),
+            dtp;
+        $(document).find('body').append(dtpElement);
+
+        expect(function () {
+            expect(dtpElement.datetimepicker(options)).toBe(dtpElement);
+        }).not.toThrow();
+
+        dtp = dtpElement.data('DateTimePicker');
         expect(dtp).not.toBe(null);
+        expect(dtp.options()).toEqual($.extend(true, {}, dtpElement.datetimepicker.defaults, options));
+    });
+
+    it('does not accept non-object or string types', function () {
+        var dtpElement = $('<input>');
+        $(document).find('body').append(dtpElement);
+
+        expect(function () {
+            dtpElement.datetimepicker(true);
+        }).toThrow();
     });
 
     xit('calls destroy when Element that the component is attached is removed', function () {
@@ -66,6 +92,14 @@ describe('Public API method tests', function () {
             it('has function ' + key + '()', function () {
                 expect(dtp[key]).toBeDefined();
             });
+        });
+    });
+
+    describe('unknown functions', function () {
+        it('are not allowed', function () {
+            expect(function () {
+                dtpElement.datetimepicker('abcdef');
+            }).toThrow();
         });
     });
 
@@ -131,6 +165,18 @@ describe('Public API method tests', function () {
                 expect(dtp.date().isSame(timestamp)).toBe(true);
             });
         });
+
+        describe('access', function () {
+            it('gets date', function () {
+                expect(dtpElement.datetimepicker('date')).toBe(null);
+            });
+
+            it('sets date', function () {
+                var timestamp = moment();
+                expect(dtpElement.datetimepicker('date', timestamp)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('date').isSame(timestamp)).toBe(true);
+            });
+        });
     });
 
     describe('format() function', function () {
@@ -172,8 +218,21 @@ describe('Public API method tests', function () {
             });
 
             it('sets the format correctly', function () {
-                dtp.format('YYYY-MM-DD');
-                expect(dtp.format()).toBe('YYYY-MM-DD');
+                var format = 'YYYY-MM-DD';
+                dtp.format(format);
+                expect(dtp.format()).toBe(format);
+            });
+        });
+
+        describe('access', function () {
+            it('gets format', function () {
+                expect(dtpElement.datetimepicker('format')).toBe(false);
+            });
+
+            it('sets format', function () {
+                var format = 'YYYY-MM-DD';
+                expect(dtpElement.datetimepicker('format', format)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('format')).toBe(format);
             });
         });
     });
@@ -182,6 +241,12 @@ describe('Public API method tests', function () {
         describe('existence', function () {
             it('is defined', function () {
                 expect(dtp.destroy).toBeDefined();
+            });
+        });
+
+        describe('access', function () {
+            it('returns jQuery object', function () {
+                expect(dtpElement.datetimepicker('destroy')).toBe(dtpElement);
             });
         });
     });
@@ -196,6 +261,12 @@ describe('Public API method tests', function () {
         // describe('functionality', function () {
         //     it('')
         // });
+
+        describe('access', function () {
+            it('returns jQuery object', function () {
+                expect(dtpElement.datetimepicker('toggle')).toBe(dtpElement);
+            });
+        });
     });
 
     describe('show() function', function () {
@@ -222,6 +293,12 @@ describe('Public API method tests', function () {
             it('actually shows the widget', function () {
                 dtp.show();
                 expect($(document).find('body').find('.bootstrap-datetimepicker-widget').length).toEqual(1);
+            });
+        });
+
+        describe('access', function () {
+            it('returns jQuery object', function () {
+                expect(dtpElement.datetimepicker('show')).toBe(dtpElement);
             });
         });
     });
@@ -251,12 +328,24 @@ describe('Public API method tests', function () {
                 expect($(document).find('body').find('.bootstrap-datetimepicker-widget').length).toEqual(0);
             });
         });
+
+        describe('access', function () {
+            it('returns jQuery object', function () {
+                expect(dtpElement.datetimepicker('hide')).toBe(dtpElement);
+            });
+        });
     });
 
     describe('disable() function', function () {
         describe('existence', function () {
             it('is defined', function () {
                 expect(dtp.disable).toBeDefined();
+            });
+        });
+
+        describe('access', function () {
+            it('returns jQuery object', function () {
+                expect(dtpElement.datetimepicker('disable')).toBe(dtpElement);
             });
         });
     });
@@ -267,12 +356,30 @@ describe('Public API method tests', function () {
                 expect(dtp.enable).toBeDefined();
             });
         });
+
+        describe('access', function () {
+            it('returns jQuery object', function () {
+                expect(dtpElement.datetimepicker('enable')).toBe(dtpElement);
+            });
+        });
     });
 
     describe('options() function', function () {
         describe('existence', function () {
             it('is defined', function () {
                 expect(dtp.options).toBeDefined();
+            });
+        });
+
+        describe('access', function () {
+            it('gets options', function () {
+                expect(dtpElement.datetimepicker('options')).toEqual(dtpElement.datetimepicker.defaults);
+            });
+
+            it('sets options', function () {
+                var options = {locale: 'fr'};
+                expect(dtpElement.datetimepicker('options', options)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('options')).toEqual($.extend(true, {}, dtpElement.datetimepicker.defaults, options));
             });
         });
     });
@@ -283,12 +390,36 @@ describe('Public API method tests', function () {
                 expect(dtp.disabledDates).toBeDefined();
             });
         });
+
+        describe('access', function () {
+            it('gets disabled dates', function () {
+                expect(dtpElement.datetimepicker('disabledDates')).toBe(false);
+            });
+
+            it('sets disabled dates', function () {
+                var timestamps = [moment()];
+                expect(dtpElement.datetimepicker('disabledDates', timestamps)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('disabledDates')).not.toBe(false);
+            });
+        });
     });
 
     describe('enabledDates() function', function () {
         describe('existence', function () {
             it('is defined', function () {
                 expect(dtp.enabledDates).toBeDefined();
+            });
+        });
+
+        describe('access', function () {
+            it('gets enabled dates', function () {
+                expect(dtpElement.datetimepicker('enabledDates')).toBe(false);
+            });
+
+            it('sets enabled dates', function () {
+                var timestamps = [moment()];
+                expect(dtpElement.datetimepicker('enabledDates', timestamps)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('enabledDates')).not.toBe(false);
             });
         });
     });
@@ -299,6 +430,18 @@ describe('Public API method tests', function () {
                 expect(dtp.daysOfWeekDisabled).toBeDefined();
             });
         });
+
+        describe('access', function () {
+            xit('gets days of week disabled', function () {
+                expect(dtpElement.datetimepicker('daysOfWeekDisabled')).toEqual([]);
+            });
+
+            it('sets days of week disabled', function () {
+                var daysOfWeek = [0];
+                expect(dtpElement.datetimepicker('daysOfWeekDisabled', daysOfWeek)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('daysOfWeekDisabled')).toEqual(daysOfWeek);
+            });
+        });
     });
 
     describe('maxDate() function', function () {
@@ -307,12 +450,36 @@ describe('Public API method tests', function () {
                 expect(dtp.maxDate).toBeDefined();
             });
         });
+
+        describe('access', function () {
+            it('gets max date', function () {
+                expect(dtpElement.datetimepicker('maxDate')).toBe(false);
+            });
+
+            it('sets max date', function () {
+                var timestamp = moment();
+                expect(dtpElement.datetimepicker('maxDate', timestamp)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('maxDate').isSame(timestamp)).toBe(true);
+            });
+        });
     });
 
     describe('minDate() function', function () {
         describe('existence', function () {
             it('is defined', function () {
                 expect(dtp.minDate).toBeDefined();
+            });
+        });
+
+        describe('access', function () {
+            it('gets min date', function () {
+                expect(dtpElement.datetimepicker('minDate')).toBe(false);
+            });
+
+            it('sets min date', function () {
+                var timestamp = moment();
+                expect(dtpElement.datetimepicker('minDate', timestamp)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('minDate').isSame(timestamp)).toBe(true);
             });
         });
     });
@@ -348,6 +515,18 @@ describe('Public API method tests', function () {
                 expect(dtp.date().isSame(timestamp)).toBe(true);
             });
         });
+
+        describe('access', function () {
+            it('gets default date', function () {
+                expect(dtpElement.datetimepicker('defaultDate')).toBe(false);
+            });
+
+            it('sets default date', function () {
+                var timestamp = moment();
+                expect(dtpElement.datetimepicker('defaultDate', timestamp)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('defaultDate').isSame(timestamp)).toBe(true);
+            });
+        });
     });
 
     describe('locale() function', function () {
@@ -362,6 +541,18 @@ describe('Public API method tests', function () {
                 expect(dtp.locale()).toBe('el');
                 expect(dtp.date().locale()).toBe('el');
                 expect(moment.locale()).toBe('en');
+            });
+        });
+
+        describe('access', function () {
+            it('gets locale', function () {
+                expect(dtpElement.datetimepicker('locale')).toBe(moment.locale());
+            });
+
+            it('sets locale', function () {
+                var locale = 'fr';
+                expect(dtpElement.datetimepicker('locale', locale)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('locale')).toBe(locale);
             });
         });
     });
@@ -404,12 +595,36 @@ describe('Public API method tests', function () {
                 expect(dpChangeSpy).toHaveBeenCalled();
             });
         });
+
+        describe('access', function () {
+            it('gets use current', function () {
+                expect(dtpElement.datetimepicker('useCurrent')).toBe(true);
+            });
+
+            it('sets use current', function () {
+                var useCurrent = false;
+                expect(dtpElement.datetimepicker('useCurrent', useCurrent)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('useCurrent')).toBe(useCurrent);
+            });
+        });
     });
 
     describe('ignoreReadonly() function', function () {
         describe('existence', function () {
             it('is defined', function () {
                 expect(dtp.ignoreReadonly).toBeDefined();
+            });
+        });
+
+        describe('access', function () {
+            it('gets ignore readonly', function () {
+                expect(dtpElement.datetimepicker('ignoreReadonly')).toBe(false);
+            });
+
+            it('sets ignore readonly', function () {
+                var ignoreReadonly = true;
+                expect(dtpElement.datetimepicker('ignoreReadonly', ignoreReadonly)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('ignoreReadonly')).toBe(ignoreReadonly);
             });
         });
     });
@@ -420,12 +635,36 @@ describe('Public API method tests', function () {
                 expect(dtp.stepping).toBeDefined();
             });
         });
+
+        describe('access', function () {
+            it('gets stepping', function () {
+                expect(dtpElement.datetimepicker('stepping')).toBe(1);
+            });
+
+            it('sets stepping', function () {
+                var stepping = 2;
+                expect(dtpElement.datetimepicker('stepping', stepping)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('stepping')).toBe(stepping);
+            });
+        });
     });
 
     describe('collapse() function', function () {
         describe('existence', function () {
             it('is defined', function () {
                 expect(dtp.collapse).toBeDefined();
+            });
+        });
+
+        describe('access', function () {
+            it('gets collapse', function () {
+                expect(dtpElement.datetimepicker('collapse')).toBe(true);
+            });
+
+            it('sets collapse', function () {
+                var collapse = false;
+                expect(dtpElement.datetimepicker('collapse', collapse)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('collapse')).toBe(collapse);
             });
         });
     });
@@ -436,12 +675,36 @@ describe('Public API method tests', function () {
                 expect(dtp.icons).toBeDefined();
             });
         });
+
+        describe('access', function () {
+            it('gets icons', function () {
+                expect(dtpElement.datetimepicker('icons')).toEqual(dtpElement.datetimepicker.defaults.icons);
+            });
+
+            it('sets icons', function () {
+                var icons = {time: 'fa fa-time'};
+                expect(dtpElement.datetimepicker('icons', icons)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('icons')).toEqual($.extend(true, {}, dtpElement.datetimepicker.defaults.icons, icons));
+            });
+        });
     });
 
     describe('useStrict() function', function () {
         describe('existence', function () {
             it('is defined', function () {
                 expect(dtp.useStrict).toBeDefined();
+            });
+        });
+
+        describe('access', function () {
+            it('gets use strict', function () {
+                expect(dtpElement.datetimepicker('useStrict')).toBe(false);
+            });
+
+            it('sets use strict', function () {
+                var useStrict = true;
+                expect(dtpElement.datetimepicker('useStrict', useStrict)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('useStrict')).toBe(useStrict);
             });
         });
     });
@@ -452,12 +715,36 @@ describe('Public API method tests', function () {
                 expect(dtp.sideBySide).toBeDefined();
             });
         });
+
+        describe('access', function () {
+            it('gets side-by-side', function () {
+                expect(dtpElement.datetimepicker('sideBySide')).toBe(false);
+            });
+
+            it('sets side-by-side', function () {
+                var sideBySide = true;
+                expect(dtpElement.datetimepicker('sideBySide', sideBySide)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('sideBySide')).toBe(sideBySide);
+            });
+        });
     });
 
     describe('viewMode() function', function () {
         describe('existence', function () {
             it('is defined', function () {
                 expect(dtp.viewMode).toBeDefined();
+            });
+        });
+
+        describe('access', function () {
+            it('gets view mode', function () {
+                expect(dtpElement.datetimepicker('viewMode')).toBe('days');
+            });
+
+            it('sets view mode', function () {
+                var viewMode = 'years';
+                expect(dtpElement.datetimepicker('viewMode', viewMode)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('viewMode')).toBe(viewMode);
             });
         });
     });
@@ -468,12 +755,36 @@ describe('Public API method tests', function () {
                 expect(dtp.widgetPositioning).toBeDefined();
             });
         });
+
+        describe('access', function () {
+            it('gets widget positioning', function () {
+                expect(dtpElement.datetimepicker('widgetPositioning')).toEqual(dtpElement.datetimepicker.defaults.widgetPositioning);
+            });
+
+            it('sets widget positioning', function () {
+                var widgetPositioning = {horizontal: 'left'};
+                expect(dtpElement.datetimepicker('widgetPositioning', widgetPositioning)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('widgetPositioning')).toEqual($.extend(true, {}, dtpElement.datetimepicker.defaults.widgetPositioning, widgetPositioning));
+            });
+        });
     });
 
     describe('calendarWeeks() function', function () {
         describe('existence', function () {
             it('is defined', function () {
                 expect(dtp.calendarWeeks).toBeDefined();
+            });
+        });
+
+        describe('access', function () {
+            it('gets calendar weeks', function () {
+                expect(dtpElement.datetimepicker('calendarWeeks')).toBe(false);
+            });
+
+            it('sets calendar weeks', function () {
+                var calendarWeeks = true;
+                expect(dtpElement.datetimepicker('calendarWeeks', calendarWeeks)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('calendarWeeks')).toBe(calendarWeeks);
             });
         });
     });
@@ -484,12 +795,36 @@ describe('Public API method tests', function () {
                 expect(dtp.showTodayButton).toBeDefined();
             });
         });
+
+        describe('access', function () {
+            it('gets show today button', function () {
+                expect(dtpElement.datetimepicker('showTodayButton')).toBe(false);
+            });
+
+            it('sets show today button', function () {
+                var showTodayButton = true;
+                expect(dtpElement.datetimepicker('showTodayButton', showTodayButton)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('showTodayButton')).toBe(showTodayButton);
+            });
+        });
     });
 
     describe('showClear() function', function () {
         describe('existence', function () {
             it('is defined', function () {
                 expect(dtp.showClear).toBeDefined();
+            });
+        });
+
+        describe('access', function () {
+            it('gets show clear', function () {
+                expect(dtpElement.datetimepicker('showClear')).toBe(false);
+            });
+
+            it('sets show clear', function () {
+                var showClear = true;
+                expect(dtpElement.datetimepicker('showClear', showClear)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('showClear')).toBe(showClear);
             });
         });
     });
@@ -537,6 +872,18 @@ describe('Public API method tests', function () {
                 expect(dtp.dayViewHeaderFormat()).toBe('MM YY');
             });
         });
+
+        describe('access', function () {
+            it('gets day view header format', function () {
+                expect(dtpElement.datetimepicker('dayViewHeaderFormat')).toBe('MMMM YYYY');
+            });
+
+            it('sets day view header format', function () {
+                var dayViewHeaderFormat = 'MM YY';
+                expect(dtpElement.datetimepicker('dayViewHeaderFormat', dayViewHeaderFormat)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('dayViewHeaderFormat')).toBe(dayViewHeaderFormat);
+            });
+        });
     });
 
     describe('extraFormats() function', function () {
@@ -582,6 +929,18 @@ describe('Public API method tests', function () {
                 expect(dtp.extraFormats()[0]).toBe('YYYY-MM-DD');
             });
         });
+
+        describe('access', function () {
+            it('gets extra formats', function () {
+                expect(dtpElement.datetimepicker('extraFormats')).toBe(false);
+            });
+
+            it('sets extra formats', function () {
+                var extraFormats = ['YYYY-MM-DD'];
+                expect(dtpElement.datetimepicker('extraFormats', extraFormats)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('extraFormats')).toEqual(extraFormats);
+            });
+        });
     });
 
     describe('toolbarPlacement() function', function () {
@@ -616,6 +975,18 @@ describe('Public API method tests', function () {
                 expect(function () {
                     dtp.toolbarPlacement({});
                 }).toThrow();
+            });
+        });
+
+        describe('access', function () {
+            it('gets toolbar placement', function () {
+                expect(dtpElement.datetimepicker('toolbarPlacement')).toBe('default');
+            });
+
+            it('sets toolbar placement', function () {
+                var toolbarPlacement = 'top';
+                expect(dtpElement.datetimepicker('toolbarPlacement', toolbarPlacement)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('toolbarPlacement')).toBe(toolbarPlacement);
             });
         });
     });
@@ -664,12 +1035,35 @@ describe('Public API method tests', function () {
                 }).toThrow();
             });
         });
+
+        describe('access', function () {
+            it('gets widget parent', function () {
+                expect(dtpElement.datetimepicker('widgetParent')).toBe(null);
+            });
+
+            it('sets widget parent', function () {
+                expect(dtpElement.datetimepicker('widgetParent', 'testDiv')).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('widgetParent')).not.toBe(null);
+            });
+        });
     });
 
     describe('keepOpen() function', function () {
         describe('existence', function () {
             it('is defined', function () {
                 expect(dtp.keepOpen).toBeDefined();
+            });
+        });
+
+        describe('access', function () {
+            it('gets keep open', function () {
+                expect(dtpElement.datetimepicker('keepOpen')).toBe(false);
+            });
+
+            it('sets keep open', function () {
+                var keepOpen = true;
+                expect(dtpElement.datetimepicker('keepOpen', keepOpen)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('keepOpen')).toBe(keepOpen);
             });
         });
     });
@@ -680,12 +1074,30 @@ describe('Public API method tests', function () {
                 expect(dtp.inline).toBeDefined();
             });
         });
+
+        describe('access', function () {
+            it('gets inline', function () {
+                expect(dtpElement.datetimepicker('inline')).toBe(false);
+            });
+
+            it('sets inline', function () {
+                var inline = true;
+                expect(dtpElement.datetimepicker('inline', inline)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('inline')).toBe(inline);
+            });
+        });
     });
 
     describe('clear() function', function () {
         describe('existence', function () {
             it('is defined', function () {
                 expect(dtp.clear).toBeDefined();
+            });
+        });
+
+        describe('access', function () {
+            it('returns jQuery object', function () {
+                expect(dtpElement.datetimepicker('clear')).toBe(dtpElement);
             });
         });
     });
@@ -696,12 +1108,36 @@ describe('Public API method tests', function () {
                 expect(dtp.keyBinds).toBeDefined();
             });
         });
+
+        describe('access', function () {
+            it('gets key binds', function () {
+                expect(dtpElement.datetimepicker('keyBinds')).toEqual(dtpElement.datetimepicker.defaults.keyBinds);
+            });
+
+            it('sets key binds', function () {
+                var keyBinds = {up: function () {}};
+                expect(dtpElement.datetimepicker('keyBinds', keyBinds)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('keyBinds')).toEqual(keyBinds);
+            });
+        });
     });
 
     describe('parseInputDate() function', function () {
         describe('existence', function () {
             it('is defined', function () {
                 expect(dtp.parseInputDate).toBeDefined();
+            });
+        });
+
+        describe('access', function () {
+            it('gets parse input date', function () {
+                expect(dtpElement.datetimepicker('parseInputDate')).toBe(undefined);
+            });
+
+            it('sets parse input date', function () {
+                var parseInputDate = function () {};
+                expect(dtpElement.datetimepicker('parseInputDate', parseInputDate)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('parseInputDate')).toBe(parseInputDate);
             });
         });
     });


### PR DESCRIPTION
This plugin has the widest and most configurable API that I have seen for a date picker widget and the documentation is fantastic, simple, and clear. Thank you!

That said; I noticed a slight abnormality with how to access this API. It's become almost a standard for top jQuery plugins to expose their API via the plugin method itself. For example;

``` javascript
// initialize plugin with default options
$(element).datetimepicker()
// initialize plugin with custom options on top of the defaults
$(element).datetimepicker({ locale: 'fr' })

// get a value
$(element).datetimepicker('date')

// set a value
$(element).datetimepicker('date', moment())

// perform a single action
$(element).datetimepicker('toggle')

// perform a chain of actions
$(element)
    .datetimepicker('show')
    .datetimepicker('date', moment())
    .datetimepicker('destroy')
```

This PR aims to add such support to this plugin in a non-breaking way (existing pattern will still work) and that also has minimum overhead.

This has been achieved by returning the return value of the called method unless it's a picker, which I'm treating as void and therefore returning the jQuery object to support chaining. I noticed that 4 methods did not return anything (really void), so there's a small workaround for these edge cases.

### Caveats

As with every approach, there are some caveats, and I'd like to highlight these up front. These are generally considered the "norm", I believe, but I'll like to call them out anyway:

- When a getter method is called when multiple elements are select, only the result of the last selected element will be returned
- When attempting to call a method on an element where the plugin has not been initialized previously, an error is thrown (regardless of whether it was the only element selected or one of many)

### Testing

I want to call this out immediately; **I have not updated any tests**. Yet! I wanted to get this PR opened early to see if there was a desire for this feature before spending time on the tests. I also hoped to get input on how the testing should be done as I see a couple of options for this:

1. Add tests that *only* cover the changes that I've made
2. Add tests for the new error cases (i.e. method called when plugin not initialized, jQuery plugin method passed first arg with unexpected data type) and then change *all existing tests* to use the new pattern for full test coverage

Obviously, the first option would be the smallest and have the least impact. The second option would be if you wanted to switch to the new pattern as your primary recommended pattern, which I be no means wish to push on anyone, but you may want to do so, so I'm just putting it out there.

For the same reason, I have also not updated any documentation or examples etc.

To clarify; I will write the tests before this PR is accepted, I just wanted guidance on how best to approach the tests.

---

Thoughts?