### PR TITLE
selectWeek option

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -386,6 +386,23 @@ Takes a `boolean` variable to set if the week numbers will appear to the left on
 
 ----------------------
 
+### selectWeeks
+
+	Default: false
+
+Hightlights whole month row on date selection. Returned result still depends on `format`
+
+![selectWeeks](img/selectWeeks.png)
+
+#### selectWeeks()
+
+Returns a `boolean` with the current `options.selectWeeks` option configuration
+
+#### selectWeeks(boolean)
+
+Takes a `boolean` variable to set if week selection is turned on
+----------------------
+
 ### viewMode
 
 	Default: 'days'

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -700,6 +700,10 @@
                 daysViewHeader.eq(1).attr('title', options.tooltips.selectMonth);
                 daysViewHeader.eq(2).find('span').attr('title', options.tooltips.nextMonth);
 
+                if (options.selectWeek) {
+                    daysView.addClass('select-week');
+                }
+
                 daysView.find('.disabled').removeClass('disabled');
                 daysViewHeader.eq(1).text(viewDate.format(options.dayViewHeaderFormat));
 
@@ -717,6 +721,9 @@
                         row = $('<tr>');
                         if (options.calendarWeeks) {
                             row.append('<td class="cw">' + currentDate.week() + '</td>');
+                            if (options.selectWeek && currentDate.isSame(date, 'w') && !unset) {
+                                row.addClass('highlighted');
+                            }
                         }
                         html.push(row);
                     }
@@ -1997,6 +2004,20 @@
             }
 
             options.calendarWeeks = calendarWeeks;
+            update();
+            return picker;
+        };
+
+        picker.selectWeek = function (selectWeek) {
+            if (arguments.length === 0) {
+                return options.selectWeek;
+            }
+
+            if (typeof selectWeek !== 'boolean') {
+                throw new TypeError('selectWeek() expects parameter to be a boolean value');
+            }
+
+            options.selectWeek = selectWeek;
             update();
             return picker;
         };

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -160,6 +160,8 @@
                         return actualFormat.indexOf('Y') !== -1;
                     case 'M':
                         return actualFormat.indexOf('M') !== -1;
+                    case 'w':
+                        return actualFormat.toLowerCase().indexOf('w') !== -1;
                     case 'd':
                         return actualFormat.toLowerCase().indexOf('d') !== -1;
                     case 'h':
@@ -183,7 +185,7 @@
             },
 
             hasDate = function () {
-                return (isEnabled('y') || isEnabled('M') || isEnabled('d'));
+                return (isEnabled('y') || isEnabled('M') || isEnabled('d') || isEnabled('w'));
             },
 
             getDatePickerTemplate = function () {
@@ -1413,7 +1415,7 @@
                 if (isEnabled('M')) {
                     minViewModeNumber = 1;
                 }
-                if (isEnabled('d')) {
+                if (isEnabled('d') || isEnabled('w')) {
                     minViewModeNumber = 0;
                 }
 

--- a/src/less/_bootstrap-datetimepicker.less
+++ b/src/less/_bootstrap-datetimepicker.less
@@ -329,13 +329,29 @@
         }
     }
 
+    .datepicker-days.select-week {
+        tr.highlighted td {
+            background-color: @bs-datetimepicker-active-bg;
+            color: @bs-datetimepicker-active-color;
+            text-shadow: @bs-datetimepicker-text-shadow;
+            border-radius: 0;
+
+            &:first-child {
+                border-radius: @bs-datetimepicker-border-radius 0 0 @bs-datetimepicker-border-radius;
+            }
+            &:last-child {
+                border-radius: 0 @bs-datetimepicker-border-radius @bs-datetimepicker-border-radius 0;
+            }
+        }
+    }
+
     &.usetwentyfour {
         td.hour {
             height: 27px;
             line-height: 27px;
         }
     }
-	
+
 	&.wider {
 		width: 21em;
 	}

--- a/src/sass/_bootstrap-datetimepicker.scss
+++ b/src/sass/_bootstrap-datetimepicker.scss
@@ -328,6 +328,22 @@ $bs-datetimepicker-text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25) !default;
         }
     }
 
+    .datepicker-days.select-week {
+        tr.highlighted td {
+            background-color: @bs-datetimepicker-active-bg;
+            color: @bs-datetimepicker-active-color;
+            text-shadow: @bs-datetimepicker-text-shadow;
+            border-radius: 0;
+
+            &:first-child {
+                border-radius: @bs-datetimepicker-border-radius 0 0 @bs-datetimepicker-border-radius;
+            }
+            &:last-child {
+                border-radius: 0 @bs-datetimepicker-border-radius @bs-datetimepicker-border-radius 0;
+            }
+        }
+    }
+
     &.usetwentyfour {
         td.hour {
             height: 27px;


### PR DESCRIPTION
I implemented a simple week selection solution, just a visual change and one fix for `format` option parsing.
Calendar still selects a single date, use `format` option e.g. `format: 'gg/wwww'` to get week number.
