### PR TITLE
Change dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/eonasdan/bootstrap-datetimepicker/issues"
   },
-  "dependencies": {
+  "peerDependencies": {
     "bootstrap": "^3.3",
     "jquery": ">=1.8.3 <2.2.0",
     "moment": "~2.10.5",


### PR DESCRIPTION
Using dependencies will result in a separate version installed under the modules `node_modules`. This means that for example the `moment` we use in our project is not the same as the one used by `bootstrap -datepicker`, so we can not load locales beforehand.

With peerDependencies this will not happen, instead it will print a warning if the versions do not match. But of course (at least with npm3) you have to install the dependencies by yourself.
