### PR TITLE
Add validator logic, allowing external validators to validate the date & time

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -545,6 +545,9 @@
                 if (!targetMoment.isValid()) {
                     return false;
                 }
+                if (options.validator && options.validatorFor.indexOf(granularity) >= 0) {
+                    return options.validator(targetMoment, granularity);
+                }
                 if (options.disabledDates && granularity === 'd' && isInDisabledDates(targetMoment)) {
                     return false;
                 }
@@ -2205,6 +2208,39 @@
             return picker;
         };
 
+        picker.validator = function(validator) {
+            if (arguments.length === 0) {
+                return (options.validator ? $.extend({}, options.validator) : options.validator);
+            }
+            if (!validator) {
+                options.validator = false;
+                update();
+                return picker;
+            }
+            var isFunction = function(obj) {
+              return !!(obj && obj.constructor && obj.call && obj.apply);
+            };
+            if (!(isFunction(validator))) {
+                throw new TypeError('validator() expects a function parameter');
+            }
+            options.validator = validator;
+            update();
+            return picker;
+        };
+
+        picker.validatorFor = function (validatorFor) {
+            if (arguments.length === 0) {
+                return options.validatorFor;
+            }
+
+            if (typeof validatorFor !== 'string') {
+                throw new TypeError('validatorFor() expects a string parameter');
+            }
+
+            options.validatorFor = validatorFor;
+            return picker;
+        };
+
         picker.disabledHours = function (hours) {
             ///<signature helpKeyword="$.fn.datetimepicker.disabledHours">
             ///<summary>Returns an array with the currently set disabled hours on the component.</summary>
@@ -2559,6 +2595,8 @@
         disabledTimeIntervals: false,
         disabledHours: false,
         enabledHours: false,
+        validator: false,
+        validatorFor: 'dhms',
         viewDate: false
     };
     module.exports = $.fn.datetimepicker;

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -2208,7 +2208,7 @@
             return picker;
         };
 
-        picker.validator = function(validator) {
+        picker.validator = function (validator) {
             if (arguments.length === 0) {
                 return (options.validator ? $.extend({}, options.validator) : options.validator);
             }
@@ -2217,8 +2217,8 @@
                 update();
                 return picker;
             }
-            var isFunction = function(obj) {
-              return !!(obj && obj.constructor && obj.call && obj.apply);
+            var isFunction = function (obj) {
+                return !!(obj && obj.constructor && obj.call && obj.apply);
             };
             if (!(isFunction(validator))) {
                 throw new TypeError('validator() expects a function parameter');


### PR DESCRIPTION
Trying this again with the development branch.

This allows for external validators to validate the date & time (specified by the granularity in validatorFor).
Through this you can use code/libraries like https://github.com/AMDmi3/opening_hours.js to validate the date/time and give a much more fine-grained control: setting holidays, or using different opening hours per day of the week.

Hopefully you will consider merging.
