### PR TITLE
Fix widget positioning relative to top of page - issue 1505

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -461,8 +461,8 @@
                 }
 
                 widget.css({
-                    top: vertical === 'top' ? 'auto' : position.top + element.outerHeight(),
-                    bottom: vertical === 'top' ? parent.outerHeight() - (parent === element ? 0 : position.top) : 'auto',
+                    top: vertical === 'top' ? position.top - widget.height() - element.outerHeight() / 2 : position.top + element.outerHeight(),
+                    bottom: 'auto',
                     left: horizontal === 'left' ? (parent === element ? 0 : position.left) : 'auto',
                     right: horizontal === 'left' ? 'auto' : parent.outerWidth() - element.outerWidth() - (parent === element ? 0 : position.left)
                 });

--- a/src/sass/_bootstrap-datetimepicker.scss
+++ b/src/sass/_bootstrap-datetimepicker.scss
@@ -269,7 +269,7 @@ $bs-datetimepicker-text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25) !default;
                     content: '';
                     display: inline-block;
                     border: solid transparent;
- +                  border-width: 0 0 7px 7px;
+                    border-width: 0 0 7px 7px;
                     border-bottom-color: $bs-datetimepicker-active-bg;
                     border-top-color: $bs-datetimepicker-secondary-border-color-rgba;
                     position: absolute;


### PR DESCRIPTION
Widget now positions itself relative to the top of the page rather than to the bottom of the page. This fixes an issue where the widget is positioned incorrectly in some cases.
