### PR TITLE
TBODY of time-picker to be in LTR not to break time display in RTL

### DIFF
--- a/src/less/_bootstrap-datetimepicker.less
+++ b/src/less/_bootstrap-datetimepicker.less
@@ -343,6 +343,10 @@
 	& .datepicker-decades .decade {
         line-height: 1.8em !important;
     }
+
+    & .timepicker-picker tbody {
+        direction: ltr;
+    }
 }
 
 .input-group.date {

--- a/src/sass/_bootstrap-datetimepicker.scss
+++ b/src/sass/_bootstrap-datetimepicker.scss
@@ -334,6 +334,10 @@ $bs-datetimepicker-text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25) !default;
             line-height: 27px;
         }
     }
+
+    .timepicker-picker tbody {
+        direction: ltr;
+    }
 }
 
 .input-group.date {


### PR DESCRIPTION
In RTL the time table would also inherit the right-to-left display and so it will show time in a reversed format as table cells are reversed in right-to-left languages (for example `32 : 13` instead of `13 : 32`).

This commit makes sure the `TBODY` tag of `.time-display` is set to LTR.