### PR TITLE
Reduce jQuery version contraints

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "moment": "~2.8",
         "moment-timezone" : "~0.4",
         "bootstrap": "^3.3",
-        "jquery": ">=1.8.3 <2.2.0"
+        "jquery": "^1.8.3 || ^2.0"
     },
     "description": "A date/time picker component designed to work with Bootstrap 3 and Momentjs. For usage, installation and demos see Project Site on GitHub",
     "devDependencies": {


### PR DESCRIPTION
Currently, using a jQuery version newer than 2.2 is not allowed. This change makes it less restrictive.