### PR TITLE
Reduce the jQuery and Moment version constraints

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   },
   "dependencies": {
     "bootstrap": "^3.3",
-    "jquery": ">=1.8.3 <2.2.0",
-    "moment": "~2.10.5",
+    "jquery": "^1.8.3 || ^2.0",
+    "moment": "^2.10",
     "moment-timezone": "^0.4.0"
   },
   "description": "A date/time picker component designed to work with Bootstrap 3 and Momentjs. For usage, installation and demos see Project Site on GitHub",


### PR DESCRIPTION
Currently, using a jQuery version newer than 2.2 is not allowed. This change makes it less restrictive.

Also, allows Moment versions newer than 2.10.