### PR TITLE
Fixed problem with DST

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -151,10 +151,10 @@
                     }
                 } else {
                     if (tzEnabled) {
-                        currentZoneOffset = moment().tz(options.timeZone).utcOffset();
+                        currentZoneOffset = moment(d, parseFormats, options.useStrict).tz(options.timeZone).utcOffset();
                         incomingZoneOffset = moment(d, parseFormats, options.useStrict).utcOffset();
                         if (incomingZoneOffset !== currentZoneOffset) {
-                            timeZoneIndicator = moment().tz(options.timeZone).format('Z');
+                            timeZoneIndicator = moment(d, parseFormats, options.useStrict).tz(options.timeZone).format('Z');
                             dateWithTimeZoneInfo = moment(d, parseFormats, options.useStrict).format('YYYY-MM-DD[T]HH:mm:ss') + timeZoneIndicator;
                             returnMoment = moment(dateWithTimeZoneInfo, parseFormats, options.useStrict).tz(options.timeZone);
                         } else {


### PR DESCRIPTION
tl;dr **We should be looking at the time zone offset at the target moment, not the time zone offset at current moment. Even though we use the same time zone, the offsets changes depending on the date (depends on DST).**

The offset computation of `moment().tz(options.timeZone)` code used in the `getMoment` function can refer to wrong time zone offset if the current time zone and is different from the timezone in the target moment.

This can happen for example if the current time (aka `moment()`) is in the DST and the target time (aka `moment(d, parseFormats, options.useStrict)`) is not in the DST.
