### PR TITLE
Show decades as 1900's, 1910's, 1920's, etc.

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -658,31 +658,32 @@
                     endDecade = startDecade.clone().add(100, 'y'),
                     startedAt = startDecade.clone(),
                     html = '';
-
+       
                 decadesViewHeader.eq(0).find('span').attr('title', options.tooltips.prevCentury);
                 decadesViewHeader.eq(2).find('span').attr('title', options.tooltips.nextCentury);
-
+                
                 decadesView.find('.disabled').removeClass('disabled');
-
+                
                 if (startDecade.isSame(moment({y: 1900})) || (options.minDate && options.minDate.isAfter(startDecade, 'y'))) {
                     decadesViewHeader.eq(0).addClass('disabled');
                 }
-
-                decadesViewHeader.eq(1).text(startDecade.year() + '-' + endDecade.year());
-
+                
                 if (startDecade.isSame(moment({y: 2000})) || (options.maxDate && options.maxDate.isBefore(endDecade, 'y'))) {
                     decadesViewHeader.eq(2).addClass('disabled');
                 }
-
+                
+                decadesViewHeader.eq(1).text((startedAt.year() + 1) + '-' + (startDecade.year()));
+                
                 while (!startDecade.isAfter(endDecade, 'y')) {
-                    html += '<span data-action="selectDecade" class="decade' + (startDecade.isSame(date, 'y') ? ' active' : '') +
-                        (!isValid(startDecade, 'y') ? ' disabled' : '') + '" data-selection="' + (startDecade.year() + 6) + '">' + (startDecade.year() + 1) + ' - ' + (startDecade.year() + 12) + '</span>';
-                    startDecade.add(12, 'y');
+                    var activeClass = startDecade.isSame(date, 'y') ? ' active' : '',
+                        disabledClass = !isValid(startDecade, 'y') ? ' disabled' : '',
+                        label = (startDecade.year() + 1) + "'s";
+                    html += '<span data-action="selectDecade" class="decade' + activeClass + disabledClass + '" data-selection="' + (startDecade.year() + 6) + '">' + label + '</span>';
+                    startDecade.add(10, 'y');
                 }
                 html += '<span></span><span></span><span></span>'; //push the dangling block over, at least this way it's even
-
+                
                 decadesView.find('td').html(html);
-                decadesViewHeader.eq(1).text((startedAt.year() + 1) + '-' + (startDecade.year()));
             },
 
             fillDate = function () {


### PR DESCRIPTION
The old way of showing decades kinda broke the UI and wasn't easy to scan. IMO this is superior, thoughts?

[New](https://www.dropbox.com/s/do5m81n7u169gu5/Screenshot%202016-05-06%2013.28.08.png?dl=1)