### PR TITLE
Added a new configuration option 'alwaysFireChange'

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -468,7 +468,9 @@
             },
 
             notifyEvent = function (e) {
-                if (e.type === 'dp.change' && ((e.date && e.date.isSame(e.oldDate)) || (!e.date && !e.oldDate))) {
+                if (e.type === 'dp.change' &&
+                    ((e.date && e.date.isSame(e.oldDate)) || (!e.date && !e.oldDate)) &&
+                    !options.alwaysFireChange) {
                     return;
                 }
                 element.trigger(e);
@@ -1450,6 +1452,10 @@
             }
             input.prop('disabled', true);
             return picker;
+        };
+
+        picker.alwaysFireChange = function (alwaysFireChange) {
+            options.alwaysFireChange = alwaysFireChange;
         };
 
         picker.enable = function () {
@@ -2488,6 +2494,7 @@
         daysOfWeekDisabled: false,
         calendarWeeks: false,
         viewMode: 'days',
+        alwaysFireChange: false,
         toolbarPlacement: 'default',
         showTodayButton: false,
         showClear: false,

--- a/test/publicApiSpec.js
+++ b/test/publicApiSpec.js
@@ -514,6 +514,31 @@ describe('Public API method tests', function () {
                 dtp.defaultDate(moment().year(2000));
                 expect(dtp.date().isSame(timestamp)).toBe(true);
             });
+
+            it('triggers a change event upon setting the same default date when alwaysFireChange is true and inline', function () {
+                dtp.date(null);
+                var when = moment();
+
+                dtp.alwaysFireChange(true);
+                dtp.inline(true);
+
+                dtp.defaultDate(when);
+                expect(dpChangeSpy).toHaveBeenCalled();
+                dtp.defaultDate(when);
+                expect(dpChangeSpy).toHaveBeenCalledTimes(2);
+            });
+
+            it('does not trigger a change event upon setting the same default date when alwaysFireChange is false', function () {
+                dtp.date(null);
+                var when = moment();
+
+                dtp.inline(true);
+
+                dtp.defaultDate(when);
+                expect(dpChangeSpy).toHaveBeenCalled();
+                dtp.defaultDate(when);
+                expect(dpChangeSpy).toHaveBeenCalledTimes(1);
+            });
         });
 
         describe('access', function () {


### PR DESCRIPTION
If set, the dp.change event will fire even if the actual date value had not been updated.

Resolves #993 

In addition, our use case is to update an input control not owned by the datetime control. When creating the datetime picker control with defaultDate set, it doesn't fire the dp.change event due to this behaviour. Our code is simpler for controlling the content of that input if we can just listen to the dp.change event and always expect it to fire with the current value.
