### PR TITLE
Expose the hasDate and hasTime methods publicly

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -2095,6 +2095,10 @@
             return picker;
         };
 
+        picker.hasTime = hasTime;
+
+        picker.hasDate = hasDate;
+
         picker.clear = function () {
             clear();
             return picker;

--- a/test/publicApiSpec.js
+++ b/test/publicApiSpec.js
@@ -237,6 +237,34 @@ describe('Public API method tests', function () {
         });
     });
 
+    describe('hasTime and hasDate functions', function () {
+        describe('functionality', function () {
+            it('hasTime returns true if the format has a time part', function () {
+                var format = 'HH:mm:ss';
+                dtp.format(format);
+                expect(dtp.hasTime()).toBe(true);
+            });
+
+            it('hasTime returns false if the format has no time part', function () {
+                var format = 'YYYY-MM-DD';
+                dtp.format(format);
+                expect(dtp.hasTime()).toBe(false);
+            });
+
+            it('hasDate returns true if the format has a date part', function () {
+                var format = 'YYYY-MM-DD';
+                dtp.format(format);
+                expect(dtp.hasDate()).toBe(true);
+            });
+
+            it('hasDate returns false if the format has no date part', function () {
+                var format = 'HH:mm:ss';
+                dtp.format(format);
+                expect(dtp.hasDate()).toBe(false);
+            });
+        });
+    });
+
     describe('destroy() function', function () {
         describe('existence', function () {
             it('is defined', function () {


### PR DESCRIPTION
This change exposes the hasDate and hasTime methods to external callers.

Our use case is to allow us to change the behaviour of a dropdown control containing the datetime picker depending on if it has a date picker element, time picker element or both.

Without this change, we have been duplicating the behaviour of the internal functions, by examining the value passed in as the format string, but we are concerned that it may be unreliable. We wanted a way to tell for sure that the control has a date picker, time picker or both.
