### PR TITLE
fix ui issue when picker has sideBySide and am/pm at the sametime

### DIFF
--- a/build/css/bootstrap-datetimepicker.css
+++ b/build/css/bootstrap-datetimepicker.css
@@ -355,6 +355,9 @@
 .bootstrap-datetimepicker-widget.wider {
   width: 21em;
 }
+.bootstrap-datetimepicker-widget.wider.timepicker-sbs {
+  width: 40em;
+}
 .bootstrap-datetimepicker-widget .datepicker-decades .decade {
   line-height: 1.8em !important;
 }


### PR DESCRIPTION
issue reproduce: 
$('#datetimepicker').datetimepicker({
                    debug:true, 
                    sideBySide: true,
                    format: 'DD/MMM hh:mm:ss a'
                });

verify that am/pm button is wrapped well
