### PR TITLE
Fixed issue #1555 when impossible to select the day which is minDate

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -837,6 +837,22 @@
                 fillTime();
             },
 
+            beforeUpdate = function (targetMoment) {
+                var oldDate = unset ? null : date;
+                targetMoment = targetMoment.clone().locale(options.locale);
+                date = targetMoment;
+                viewDate = date.clone();
+                input.val(date.format(actualFormat));
+                element.data('date', date.format(actualFormat));
+                unset = false;
+                update();
+                notifyEvent({
+                    type: 'dp.change',
+                    date: date.clone(),
+                    oldDate: oldDate
+                });
+            },
+
             setValue = function (targetMoment) {
                 var oldDate = unset ? null : date;
 
@@ -865,17 +881,11 @@
                 }
 
                 if (isValid(targetMoment)) {
-                    date = targetMoment;
-                    //viewDate = date.clone(); // TODO this doesn't work right on first use
-                    input.val(date.format(actualFormat));
-                    element.data('date', date.format(actualFormat));
-                    unset = false;
-                    update();
-                    notifyEvent({
-                        type: 'dp.change',
-                        date: date.clone(),
-                        oldDate: oldDate
-                    });
+                    beforeUpdate(targetMoment);
+                } else if (options.minDate && targetMoment.isSame(options.minDate, 'd')) {
+                    beforeUpdate(options.minDate);
+                } else if (options.maxDate && targetMoment.isSame(options.maxDate, 'd')) {
+                    beforeUpdate(options.maxDate);
                 } else {
                     if (!options.keepInvalid) {
                         input.val(unset ? '' : date.format(actualFormat));


### PR DESCRIPTION
It is impossible to select the day which is `minDate` when picked time is lower than `minDate`'s time. The same for `maxDate`.
I've added additional validation that sets allowed time (minimum for `minDate` and maximum for `maxDate`) when user tries to target this dates with not valid picked time.
