### PR TITLE
Added module.exports

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -39,7 +39,7 @@
         // AMD is used - Register as an anonymous module.
         define(['jquery', 'moment'], factory);
     } else if (typeof exports === 'object') {
-        factory(require('jquery'), require('moment'));
+        module.exports = factory(require('jquery'), require('moment'));
     } else {
         // Neither AMD nor CommonJS used. Use global variables.
         if (typeof jQuery === 'undefined') {


### PR DESCRIPTION
Fixed issue with Webpack and other build tools that use require or import.  The datetimepicker needs to be exported for these tools to work.  The code branch I modified should only be hit if the user is using a build tool like Webpack.

Fix directly taken from this issue: (thanks @melanke)
https://github.com/Eonasdan/bootstrap-datetimepicker/issues/1532

Should also fix: https://github.com/Eonasdan/bootstrap-datetimepicker/issues/1319