### PR TITLE
remove rouge + from sass source

### DIFF
--- a/src/sass/_bootstrap-datetimepicker.scss
+++ b/src/sass/_bootstrap-datetimepicker.scss
@@ -269,7 +269,7 @@ $bs-datetimepicker-text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25) !default;
                     content: '';
                     display: inline-block;
                     border: solid transparent;
- +                  border-width: 0 0 7px 7px;
+                    border-width: 0 0 7px 7px;
                     border-bottom-color: $bs-datetimepicker-active-bg;
                     border-top-color: $bs-datetimepicker-secondary-border-color-rgba;
                     position: absolute;


### PR DESCRIPTION
A plus sign has sneaked into the sass source, this PR just removes that, so the sass source works again.