### PR TITLE
Fixes to Issues #1645 & #1513

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -68,6 +68,7 @@
             minViewModeNumber = 0,
             actualFormat,
             parseFormats,
+            actualFormatEscapedCharsRemoved,
             currentViewMode,
             datePickerModes = [
                 {
@@ -162,18 +163,18 @@
                 }
                 switch (granularity) {
                     case 'y':
-                        return actualFormat.indexOf('Y') !== -1;
+                        return actualFormatEscapedCharsRemoved.indexOf('Y') !== -1;
                     case 'M':
-                        return actualFormat.indexOf('M') !== -1;
+                        return actualFormatEscapedCharsRemoved.indexOf('M') !== -1;
                     case 'd':
-                        return actualFormat.toLowerCase().indexOf('d') !== -1;
+                        return actualFormatEscapedCharsRemoved.toLowerCase().indexOf('d') !== -1;
                     case 'h':
                     case 'H':
-                        return actualFormat.toLowerCase().indexOf('h') !== -1;
+                        return actualFormatEscapedCharsRemoved.toLowerCase().indexOf('h') !== -1;
                     case 'm':
-                        return actualFormat.indexOf('m') !== -1;
+                        return actualFormatEscapedCharsRemoved.indexOf('m') !== -1;
                     case 's':
-                        return actualFormat.indexOf('s') !== -1;
+                        return actualFormatEscapedCharsRemoved.indexOf('s') !== -1;
                     default:
                         return false;
                 }
@@ -1398,7 +1399,9 @@
                     parseFormats.push(actualFormat);
                 }
 
-                use24Hours = (actualFormat.toLowerCase().indexOf('a') < 1 && actualFormat.replace(/\[.*?\]/g, '').indexOf('h') < 1);
+                actualFormatEscapedCharsRemoved = actualFormat.replace(/\[.*?\]/g, '');
+
+                use24Hours = (actualFormatEscapedCharsRemoved.toLowerCase().indexOf('a') < 1 && actualFormatEscapedCharsRemoved.indexOf('h') < 1);
 
                 if (isEnabled('y')) {
                     minViewModeNumber = 2;

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1104,12 +1104,24 @@
                             expanded.removeClass('in');
                             closed.addClass('in');
                         }
+                        
+                        var $parent;
+                        var $span;
                         if ($this.is('span')) {
-                            $this.toggleClass(options.icons.time + ' ' + options.icons.date);
+                            $parent = $this.parent();
+                            $span = $this;
                         } else {
-                            $this.find('span').toggleClass(options.icons.time + ' ' + options.icons.date);
+                            $parent = $this;
+                            $span = $this.find('span');
                         }
-
+                        $span.toggleClass(options.icons.time + ' ' + options.icons.date);
+                        if ($span.hasClass(options.icons.date)){
+                            $parent.attr('title',options.tooltips.selectDate);
+                        }
+                        else{
+                            $parent.attr('title',options.tooltips.selectTime);
+                        }
+                        
                         // NOTE: uncomment if toggled state will be restored in show()
                         //if (component) {
                         //    component.find('span').toggleClass(options.icons.time + ' ' + options.icons.date);
@@ -2484,7 +2496,8 @@
             incrementSecond: 'Increment Second',
             decrementSecond: 'Decrement Second',
             togglePeriod: 'Toggle Period',
-            selectTime: 'Select Time'
+            selectTime: 'Select Time',
+            selectDate: 'Select Date'
         },
         useStrict: false,
         sideBySide: false,


### PR DESCRIPTION
Issue #1645: added new actualFormatEscapedCharsRemoved variable...… with characters from actualFormat that are escaped inside square brackets as per the moment.js formatting standards removed, and then only check this new variable rather than the full actualFormat when checking if a specific letter isEnabled.

Issue #1513: added new selectDate tooltip option, and logic to use it instead of selectTime tooltip if selecting date and not time.
