### PR TITLE
Avoid container clipping & wrong placement

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -525,6 +525,23 @@ Takes a `string` or `$(element)` value.
 
 ----------------------
 
+### forceElementPosition
+
+Default: false
+
+When using widgetParent to parent the widget in the DOM, position as if parented by the input.
+Used to overcome the input container clipping the widget e.g. when styled with "overflow: hidden" (often in a table).
+
+#### forceElementPosition()
+
+Returns a `boolean` variable with the currently set `options.forceElementPosition` option.
+
+#### forceElementPosition(boolean)
+
+Takes a `boolean` value.
+
+----------------------
+
 ### keepOpen
 
 	Default: false

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -398,11 +398,13 @@
             },
 
             place = function () {
-                var position = (component || element).position(),
-                    offset = (component || element).offset(),
+                var anchorElement = options.forceElementPosition ? element : component || element,
+                    anchorPosition = anchorElement.position(),
+                    anchorOffset = anchorElement.offset(),
                     vertical = options.widgetPositioning.vertical,
                     horizontal = options.widgetPositioning.horizontal,
-                    parent;
+                    parent,
+                    parentOffset;
 
                 if (options.widgetParent) {
                     parent = options.widgetParent.append(widget);
@@ -416,10 +418,31 @@
                     element.children().first().after(widget);
                 }
 
+                // find the first parent element that has a relative css positioning
+                if (parent.css('position') !== 'relative') {
+                    parent = parent.parents().filter(function () {
+                        return $(this).css('position') === 'relative';
+                    }).first();
+                }
+
+                if (parent.length === 0) {
+                    throw new Error('datetimepicker component should be placed within a relative positioned container');
+                }
+
+                if (parent === element) {
+                    //set left from input, not component (button)
+                    anchorPosition.top = 0;    //input.position().top
+                    anchorOffset.top = input.offset().top;
+                    anchorPosition.left = 0;    //input.position().left
+                    anchorOffset.left = input.offset().left;
+                }
+
                 // Top and bottom logic
                 if (vertical === 'auto') {
-                    if (offset.top + widget.height() * 1.5 >= $(window).height() + $(window).scrollTop() &&
-                        widget.height() + element.outerHeight() < offset.top) {
+                    //if widget spacing from window bottom is less than half the widget's height
+                    // and there is enough height above
+                    if (anchorOffset.top + widget.height() * 1.5 >= $(window).height() + $(window).scrollTop() &&
+                        widget.height() + element.outerHeight() < anchorOffset.top) {
                         vertical = 'top';
                     } else {
                         vertical = 'bottom';
@@ -428,8 +451,10 @@
 
                 // Left and right logic
                 if (horizontal === 'auto') {
-                    if (parent.width() < offset.left + widget.outerWidth() / 2 &&
-                        offset.left + widget.outerWidth() > $(window).width()) {
+                    //if more than half widget is overflowing the right boundary of parent
+                    // and any of the widget is truncated by the window
+                    if (parent.width() < anchorOffset.left + widget.outerWidth() / 2 &&
+                        anchorOffset.left + widget.outerWidth() > $(window).width()) {
                         horizontal = 'right';
                     } else {
                         horizontal = 'left';
@@ -448,23 +473,23 @@
                     widget.removeClass('pull-right');
                 }
 
-                // find the first parent element that has a relative css positioning
-                if (parent.css('position') !== 'relative') {
-                    parent = parent.parents().filter(function () {
-                        return $(this).css('position') === 'relative';
-                    }).first();
+                if (!options.forceElementPosition) {
+                    widget.css({
+                        top: vertical === 'top' ? 'auto' : anchorPosition.top + element.outerHeight(),
+                        bottom: vertical === 'top' ? parent.outerHeight() - anchorPosition.top : 'auto',
+                        left: horizontal === 'left' ? anchorPosition.left : 'auto',
+                        right: horizontal === 'left' ? 'auto' : parent.outerWidth() - element.outerWidth() - anchorPosition.left
+                    });
+                } else {
+                    //Parent used only to parent widget in DOM, position relative to anchor === element
+                    parentOffset = parent.offset();
+                    widget.css({
+                        top: vertical === 'top' ? 'auto' : anchorOffset.top - parentOffset.top + element.outerHeight(),
+                        bottom: vertical === 'top' ? parent.outerHeight() - (anchorOffset.top - parentOffset.top) : 'auto',
+                        left: horizontal === 'left' ? anchorOffset.left - parentOffset.left : 'auto',
+                        right: horizontal === 'left' ? 'auto' : parent.outerWidth() - (anchorOffset.left - parentOffset.left) - element.outerWidth()
+                    });
                 }
-
-                if (parent.length === 0) {
-                    throw new Error('datetimepicker component should be placed within a relative positioned container');
-                }
-
-                widget.css({
-                    top: vertical === 'top' ? 'auto' : position.top + element.outerHeight(),
-                    bottom: vertical === 'top' ? parent.outerHeight() - (parent === element ? 0 : position.top) : 'auto',
-                    left: horizontal === 'left' ? (parent === element ? 0 : position.left) : 'auto',
-                    right: horizontal === 'left' ? 'auto' : parent.outerWidth() - element.outerWidth() - (parent === element ? 0 : position.left)
-                });
             },
 
             notifyEvent = function (e) {
@@ -2056,6 +2081,23 @@
             return picker;
         };
 
+        picker.forceElementPosition = function (forceElementPosition) {
+            if (arguments.length === 0) {
+                return options.forceElementPosition;
+            }
+
+            if (typeof forceElementPosition !== 'boolean') {
+                throw new TypeError('forceElementPosition() expects a boolean parameter');
+            }
+
+            options.forceElementPosition = forceElementPosition;
+            if (widget) {
+                hide();
+                show();
+            }
+            return picker;
+        };
+
         picker.keepOpen = function (keepOpen) {
             if (arguments.length === 0) {
                 return options.keepOpen;
@@ -2497,6 +2539,7 @@
             vertical: 'auto'
         },
         widgetParent: null,
+        forceElementPosition: false,
         ignoreReadonly: false,
         keepOpen: false,
         focusOnShow: true,

--- a/test/manual-test.html
+++ b/test/manual-test.html
@@ -1,0 +1,339 @@
+<!DOCTYPE html>
+<html><head>
+<title>bootstrap datepicker examples</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+<link rel="stylesheet" type="text/css" href="../node_modules/bootstrap/dist/css/bootstrap.css">
+<link rel="stylesheet" type="text/css" href="../build/css/bootstrap-datetimepicker.css">
+<script src="../node_modules/jquery/dist/jquery.min.js"></script>
+<script src="../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+<script src="../node_modules/moment/min/moment-with-locales.js"></script>
+<script src="../src/js/bootstrap-datetimepicker.js"></script>
+</head>
+
+<body>
+<h1>Bootstrap 3 Datepicker v4 Manual test</h1>
+
+<h3 >Minimum Setup</h3>
+<div class="container">
+    <div class="row">
+        <div class='col-sm-6'>
+            <div class="form-group">
+                <div class='input-group date' id='datetimepicker1'>
+                    <input type='text' class="form-control" />
+                    <span class="input-group-addon">
+                        <span class="glyphicon glyphicon-calendar"></span>
+                    </span>
+                </div>
+            </div>
+        </div>
+        <script type="text/javascript">
+            $(function () {
+                $('#datetimepicker1').datetimepicker();
+            });
+        </script>
+    </div>
+</div>
+
+<hr>
+<h3>Using Locales</h3>
+<div class="container">
+    <div class="row">
+        <div class='col-sm-6'>
+            <div class="form-group">
+                <div class='input-group date' id='datetimepicker2'>
+                    <input type='text' class="form-control" />
+                    <span class="input-group-addon">
+                        <span class="glyphicon glyphicon-calendar"></span>
+                    </span>
+                </div>
+            </div>
+        </div>
+        <script type="text/javascript">
+            $(function () {
+                $('#datetimepicker2').datetimepicker({
+                    locale: 'ru'
+                });
+            });
+        </script>
+    </div>
+</div>
+
+<hr>
+<h3>Time Only</h3>
+<div class="container">
+    <div class="row">
+        <div class='col-sm-6'>
+            <div class="form-group">
+                <div class='input-group date' id='datetimepicker3'>
+                    <input type='text' class="form-control" />
+                    <span class="input-group-addon">
+                        <span class="glyphicon glyphicon-time"></span>
+                    </span>
+                </div>
+            </div>
+        </div>
+        <script type="text/javascript">
+            $(function () {
+                $('#datetimepicker3').datetimepicker({
+                    format: 'LT'
+                });
+            });
+        </script>
+    </div>
+</div>
+
+<!-- <hr>
+<h3>Date Only</h3>
+Fix datetimepicker3
+<div class="container">
+    <div class="row">
+        <div class='col-sm-6'>
+            <div class="form-group">
+                <div class='input-group date' id='datetimepicker3'>
+                    <input type='text' class="form-control" />
+                    <span class="input-group-addon">
+                        <span class="glyphicon glyphicon-time"></span>
+                    </span>
+                </div>
+            </div>
+        </div>
+        <script type="text/javascript">
+            $(function () {
+                $('#datetimepicker3').datetimepicker({
+                    format: 'L'
+                });
+            });
+        </script>
+    </div>
+</div> -->
+
+<hr>
+<h3>No Icon (input field only):</h3>
+<div class="container">
+    <div class="row">
+        <div class='col-sm-6'>
+            <input type='text' class="form-control" id='datetimepicker4' />
+        </div>
+        <script type="text/javascript">
+            $(function () {
+                $('#datetimepicker4').datetimepicker();
+            });
+        </script>
+    </div>
+</div>
+
+<hr>
+<h3>Enabled/Disabled Dates</h3>
+<div class="container">
+    <div class="row">
+        <div class='col-sm-6'>
+            <div class="form-group">
+                <div class='input-group date' id='datetimepicker5'>
+                    <input type='text' class="form-control" />
+                    <span class="input-group-addon">
+                        <span class="glyphicon glyphicon-calendar"></span>
+                    </span>
+                </div>
+            </div>
+        </div>
+        <script type="text/javascript">
+            $(function () {
+                $('#datetimepicker5').datetimepicker({
+                    defaultDate: "11/1/2013",
+                    disabledDates: [
+                        moment("12/25/2013"),
+                        new Date(2013, 11 - 1, 21),
+                        "11/22/2013 00:53"
+                    ]
+                });
+            });
+        </script>
+    </div>
+</div>
+
+<hr>
+<h3>Linked Pickers</h3>
+<div class="container">
+    <div class='col-md-5'>
+        <div class="form-group">
+            <div class='input-group date' id='datetimepicker6'>
+                <input type='text' class="form-control" />
+                <span class="input-group-addon">
+                    <span class="glyphicon glyphicon-calendar"></span>
+                </span>
+            </div>
+        </div>
+    </div>
+    <div class='col-md-5'>
+        <div class="form-group">
+            <div class='input-group date' id='datetimepicker7'>
+                <input type='text' class="form-control" />
+                <span class="input-group-addon">
+                    <span class="glyphicon glyphicon-calendar"></span>
+                </span>
+            </div>
+        </div>
+    </div>
+</div>
+<script type="text/javascript">
+    $(function () {
+        $('#datetimepicker6').datetimepicker();
+        $('#datetimepicker7').datetimepicker({
+			useCurrent: false
+		});
+        $("#datetimepicker6").on("dp.change", function (e) {
+            $('#datetimepicker7').data("DateTimePicker").minDate(e.date);
+        });
+        $("#datetimepicker7").on("dp.change", function (e) {
+            $('#datetimepicker6').data("DateTimePicker").maxDate(e.date);
+        });
+    });
+</script>
+
+<hr>
+<h3>Custom Icons</h3>
+<div class="container">
+    <div class="col-sm-6" style="height:130px;">
+        <div class="form-group">
+            <div class='input-group date' id='datetimepicker8'>
+                <input type='text' class="form-control" />
+                <span class="input-group-addon">
+                    <span class="glyphicon glyphicon-list-alt">
+                    </span>
+                </span>
+            </div>
+        </div>
+    </div>
+    <script type="text/javascript">
+        $(function () {
+            $('#datetimepicker8').datetimepicker({
+                icons: {
+                    time: "glyphicon glyphicon-refresh",
+                    date: "glyphicon glyphicon-list-alt",
+                    up: "glyphicon glyphicon-upload",
+                    down: "glyphicon glyphicon-download"
+                }
+            });
+        });
+    </script>
+</div>
+
+<hr>
+<h3>View Mode</h3>
+<div class="container">
+    <div class="col-sm-6" style="height:130px;">
+        <div class="form-group">
+            <div class='input-group date' id='datetimepicker9'>
+                <input type='text' class="form-control" />
+                <span class="input-group-addon">
+                    <span class="glyphicon glyphicon-calendar">
+                    </span>
+                </span>
+            </div>
+        </div>
+    </div>
+    <script type="text/javascript">
+        $(function () {
+            $('#datetimepicker9').datetimepicker({
+                viewMode: 'years'
+            });
+        });
+    </script>
+</div>
+
+<hr>
+<h3>Min View Mode</h3>
+<div class="container">
+    <div class="col-sm-6" style="height:130px;">
+        <div class="form-group">
+            <div class='input-group date' id='datetimepicker10'>
+                <input type='text' class="form-control" />
+                <span class="input-group-addon">
+                    <span class="glyphicon glyphicon-calendar">
+                    </span>
+                </span>
+            </div>
+        </div>
+    </div>
+    <script type="text/javascript">
+        $(function () {
+            $('#datetimepicker10').datetimepicker({
+                viewMode: 'years',
+                format: 'MM/YYYY'
+            });
+        });
+    </script>
+</div>
+
+<hr>
+<h3>Disabled Days of the Week</h3>
+<div class="container">
+    <div class="col-sm-6" style="height:130px;">
+        <div class="form-group">
+            <div class='input-group date' id='datetimepicker11'>
+                <input type='text' class="form-control" />
+                <span class="input-group-addon">
+                    <span class="glyphicon glyphicon-calendar">
+                    </span>
+                </span>
+            </div>
+        </div>
+    </div>
+    <script type="text/javascript">
+        $(function () {
+            $('#datetimepicker11').datetimepicker({
+                daysOfWeekDisabled: [0, 6]
+            });
+        });
+    </script>
+</div>
+
+<hr>
+<h3>Inline</h3>
+<div style="overflow:hidden;">
+    <div class="form-group">
+        <div class="row">
+            <div class="col-md-8">
+                <div id="datetimepicker12"></div>
+            </div>
+        </div>
+    </div>
+    <script type="text/javascript">
+        $(function () {
+            $('#datetimepicker12').datetimepicker({
+                inline: true,
+                sideBySide: true
+            });
+        });
+    </script>
+</div>
+
+<hr>
+<h3>Change widget parent</h3>
+For when widget is clipped. For example by overflow: hidden. Often used in tables.
+<div class="container">
+    <div id="picker-anchor" style="position: relative;">Anchor here</div>
+    <div>Spacer to show even when widget parented by above anchor, it is display next to below input</div>
+    <div style="overflow: hidden;">
+        <div class="form-group">
+            <div class='input-group date' id='datetimepicker13'>
+                <input type='text' class="form-control" />
+                <span class="input-group-addon">
+                    <span class="glyphicon glyphicon-calendar">
+                    </span>
+                </span>
+            </div>
+        </div>
+    <div>
+    <script type="text/javascript">
+        $(function () {
+            $('#datetimepicker13').datetimepicker({
+                widgetParent: '#picker-anchor',
+                forceElementPosition: true
+            });
+        });
+    </script>
+</div>
+
+</body></html>

--- a/test/publicApiSpec.js
+++ b/test/publicApiSpec.js
@@ -1048,6 +1048,26 @@ describe('Public API method tests', function () {
         });
     });
 
+    describe('forceElementPosition() function', function () {
+        describe('existence', function () {
+            it('is defined', function () {
+                expect(dtp.forceElementPosition).toBeDefined();
+            });
+        });
+
+        describe('access', function () {
+            it('gets force element position', function () {
+                expect(dtpElement.datetimepicker('forceElementPosition')).toBe(false);
+            });
+
+            it('sets force element position', function () {
+                var forceElementPosition = true;
+                expect(dtpElement.datetimepicker('forceElementPosition', forceElementPosition)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('forceElementPosition')).toBe(forceElementPosition);
+            });
+        });
+    });
+
     describe('keepOpen() function', function () {
         describe('existence', function () {
             it('is defined', function () {


### PR DESCRIPTION
Containing elements can clip the widget (often only the widget arrow is
shown).
Often encountered when overflow: hidden style is applied inside a table.

The widgetParent can be used to show the widget, but it is often by
necessity the widgetParent is in the wrong position (e.g. outside the
table)

Added forceElementPosition option to allow DOM parenting by
widgetParent, but positioning next to the input element.

Also minor fix to Top and bottom & Left and right logic: complete
offset, position calculation before logic tests.

Added manual-test.html to allow easy development testing - dev copy of
demo.  forceElementPosition demo appended.
