### PR TITLE
Avoid widget right overlap window

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -489,12 +489,14 @@ If `true`, an icon will be displayed on the toolbar that will hide the picker
 ### widgetPositioning
 
 	Default: {
-                horizontal: 'auto'
-                vertical: 'auto'
+                horizontal: 'auto',
+                vertical: 'auto',
+                avoidRightOverlap: false
              }
     Accepts: object with the all or one of the parameters above
              horizontal: 'auto', 'left', 'right'
              vertical: 'auto', 'top', 'bottom'
+             avoidRightOverlap: true, false
 
 #### widgetPositioning()
 
@@ -505,6 +507,8 @@ Returns the currently set `options.widgetPositioning` object containing two keys
 Takes an object parameter that can contain two keys `vertical` and `horizontal` each having a value of `'auto', 'top', 'bottom'` for `vertical` and `'auto', 'left', 'right'` for `horizontal` which defines where the dropdown with the widget will appear relative to the input element the component is attached to.
 
 `'auto'` is the default value for both `horizontal` and `vertical` keys and it tries to automatically place the dropdown in a position that is visible to the user. Usually you should not override those options unless you have a special need in your layout.
+
+The 'avoidRightOverlap' key is used to always avoid the widget being placed partially off the right edge - it can have up to half off before auto changes its alignment from left to right.
 
 ----------------------
 

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -428,7 +428,13 @@
 
                 // Left and right logic
                 if (horizontal === 'auto') {
-                    if (parent.width() < offset.left + widget.outerWidth() / 2 &&
+                    if (options.widgetPositioning.avoidRightOverlap &&
+                        offset.left + widget.outerWidth() > $(window).width()) {
+                        horizontal = 'right';
+
+                        //if more than half widget is overflowing the right boundary of parent
+                        // and any of the widget is truncated by the window
+                    } else if (parent.width() < offset.left + widget.outerWidth() / 2 &&
                         offset.left + widget.outerWidth() > $(window).width()) {
                         horizontal = 'right';
                     } else {
@@ -1983,6 +1989,12 @@
                 }
                 options.widgetPositioning.vertical = widgetPositioning.vertical;
             }
+            if (widgetPositioning.avoidRightOverlap) {
+                if (typeof widgetPositioning.avoidRightOverlap !== 'boolean') {
+                    throw new TypeError('widgetPositioning() avoidRightOverlap variable must be a boolean value');
+                }
+                options.widgetPositioning.avoidRightOverlap = widgetPositioning.avoidRightOverlap;
+            }
             update();
             return picker;
         };
@@ -2494,7 +2506,8 @@
         showClose: false,
         widgetPositioning: {
             horizontal: 'auto',
-            vertical: 'auto'
+            vertical: 'auto',
+            avoidRightOverlap: false
         },
         widgetParent: null,
         ignoreReadonly: false,

--- a/test/publicApiSpec.js
+++ b/test/publicApiSpec.js
@@ -762,7 +762,7 @@ describe('Public API method tests', function () {
             });
 
             it('sets widget positioning', function () {
-                var widgetPositioning = {horizontal: 'left'};
+                var widgetPositioning = {horizontal: 'left', vertical: 'bottom', avoidRightOverlap: true};
                 expect(dtpElement.datetimepicker('widgetPositioning', widgetPositioning)).toBe(dtpElement);
                 expect(dtpElement.datetimepicker('widgetPositioning')).toEqual($.extend(true, {}, dtpElement.datetimepicker.defaults.widgetPositioning, widgetPositioning));
             });


### PR DESCRIPTION
With widgetPositioning.horizontal = auto, currently up to half the widget can be off the right edge of the window before the alignment changes from left to right.

Add widgetPositioning.avoidRightOverlap = true to prevent any overlap.

I added this as an option rather than a fix as the allowing an overlap looked deliberate, although I cant think of any scenario where it would be okay for half the widget to outside the window.
