### PR TITLE
Fix date() to reinstate handling of Date type input

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -138,15 +138,16 @@
             },
 
             getMoment = function (d) {
-                var returnMoment;
+                var returnMoment,
+                    momentFormats = (d instanceof Date) ? null : parseFormats;
 
                 if (d === undefined || d === null) {
                     returnMoment = moment(); //TODO should this use format? and locale?
                 } else if (hasTimeZone()) { // There is a string to parse and a default time zone
                     // parse with the tz function which takes a default time zone if it is not in the format string
-                    returnMoment = moment.tz(d, parseFormats, options.useStrict, options.timeZone);
+                    returnMoment = moment.tz(d, momentFormats, options.useStrict, options.timeZone);
                 } else {
-                    returnMoment = moment(d, parseFormats, options.useStrict);
+                    returnMoment = moment(d, momentFormats, options.useStrict);
                 }
 
                 if (hasTimeZone()) {


### PR DESCRIPTION
Issue: https://github.com/Eonasdan/bootstrap-datetimepicker/issues/1616

Fixed getMoment to handle Date input types

Also fixes defaultDate() & viewDate()
