### PR TITLE
fix to ensure current value fits within min and max date

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1682,7 +1682,7 @@
                 throw new TypeError('maxDate() date parameter is before options.minDate: ' + parsedDate.format(actualFormat));
             }
             options.maxDate = parsedDate;
-            if (options.useCurrent && !options.keepInvalid && date.isAfter(maxDate)) {
+            if (options.useCurrent && !options.keepInvalid && date.isAfter(options.maxDate)) {
                 setValue(options.maxDate);
             }
             if (viewDate.isAfter(parsedDate)) {
@@ -1718,7 +1718,7 @@
                 throw new TypeError('minDate() date parameter is after options.maxDate: ' + parsedDate.format(actualFormat));
             }
             options.minDate = parsedDate;
-            if (options.useCurrent && !options.keepInvalid && date.isBefore(minDate)) {
+            if (options.useCurrent && !options.keepInvalid && date.isBefore(options.minDate)) {
                 setValue(options.minDate);
             }
             if (viewDate.isBefore(parsedDate)) {


### PR DESCRIPTION
When minDate or maxDate are assigned, if the current value falls outside of the range it is supposed to reset the value.  It is not doing this for time-only values  (format of "LT").  I switched the conditional to check the parsed date object rather than the input string.  This works well because **today** is appended to the date object when doing **time** selections.
