### PR TITLE
Make datepickers not share options

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -2402,11 +2402,12 @@
 
         if (typeof options === 'object') {
             return this.each(function () {
-                var $this = $(this);
+                var $this = $(this),
+                    _options;
                 if (!$this.data('DateTimePicker')) {
                     // create a private copy of the defaults object
-                    options = $.extend(true, {}, $.fn.datetimepicker.defaults, options);
-                    $this.data('DateTimePicker', dateTimePicker($this, options));
+                    _options = $.extend(true, {}, $.fn.datetimepicker.defaults, options);
+                    $this.data('DateTimePicker', dateTimePicker($this, _options));
                 }
             });
         } else if (typeof options === 'string') {


### PR DESCRIPTION
Calling `.datetimepicker()` on a list of elements causes them to share
options, which causes issues when using data attributes to configure
datetime pickers, as pickers will get the options of the datepickers
before them in the document.

JSFiddle showing bug: https://jsfiddle.net/r4z0rw0lf/LL2xx879/1/