### PR TITLE
Fix 'control space' crash when widget is not present

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -2596,6 +2596,9 @@
             //    if(toggle.length > 0) toggle.click();
             //},
             'control space': function (widget) {
+                if (!widget) {
+                    return;
+                }
                 if (widget.find('.timepicker').is(':visible')) {
                     widget.find('.btn[data-action="togglePeriod"]').click();
                 }


### PR DESCRIPTION
Pressing 'control space' when the picker is not active causes an error in the console. Most other keyBinds have an extra check to see if the widget is present. This pull request simply adds the same check to 'control space' to get rid of the runtime error.