### PR TITLE
Fix use24hours

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1387,7 +1387,7 @@
                     parseFormats.push(actualFormat);
                 }
 
-                use24Hours = (actualFormat.toLowerCase().indexOf('a') < 1 && actualFormat.replace(/\[.*?\]/g, '').indexOf('h') < 1);
+                use24Hours = (actualFormat.replace(/\[.*?\]/g, '').toLowerCase().indexOf('a') < 1 && actualFormat.replace(/\[.*?\]/g, '').indexOf('h') < 1);
 
                 if (isEnabled('y')) {
                     minViewModeNumber = 2;


### PR DESCRIPTION
Fixes use24hours condition. If the format string contains the letter a within braces, use24hours is always false. Eg: : 'D.M.Y [ca.] HH:mm [Uhr]'