### PR TITLE
Use stopPropagation instead stopImmediatePropagation on input change.

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1315,7 +1315,7 @@
                 var val = $(e.target).val().trim(),
                     parsedDate = val ? parseInputDate(val) : null;
                 setValue(parsedDate);
-                e.stopImmediatePropagation();
+                e.stopPropagation();
                 return false;
             },
 


### PR DESCRIPTION
This allows custom code to listen to the changed event of the input,
otherwise the other events are not called. This also stops the
propagation of the event to ancestor elements.

I created this http://jsfiddle.net/19L4yt3j/ in order tot test it. 

**Current Behaviour**

When entering a valid date on the text input no change event is triggered

**PR Behaviour**

When entering a valid date on the input text, the event is triggered and the alert is shown. 

With this PR we can implement what is explained on #1562 by adding a listener for the hide and on the input manual change. As explained on the Question, using  `dp.change` is not the desired behaviour as it triggers the changes for each change of the datepicker, and we are only interested on the last value selected (manually or from picker). 

Let me know if there is something wrong with the proposal or something that I missed. 
