### PR TITLE
Fix event unbinding

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
                 'Gruntfile.js', 'src/js/*.js', 'test/*.js'
             ],
             options: {
-                'browser': true,
+                'browser': false,
                 'node': true,
                 'jquery': true,
                 'boss': false,
@@ -57,6 +57,8 @@ module.exports = function (grunt) {
                 'globals': {
                     'define': false,
                     'moment': false,
+                    'window': false,
+                    'document': false,
                     // Jasmine
                     'jasmine': false,
                     'describe': false,

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1323,42 +1323,38 @@
                 return false;
             },
 
+            inputEvents,
+            componentEvents,
+
             attachDatePickerElementEvents = function () {
-                input.on({
+                var elementIsInput = element.is('input');
+
+                inputEvents = {
                     'change': change,
                     'blur': options.debug ? '' : hide,
                     'keydown': keydown,
                     'keyup': keyup,
-                    'focus': options.allowInputToggle ? show : ''
-                });
+                    'focus': options.allowInputToggle || elementIsInput ? show : ''
+                };
+                input.on(inputEvents);
 
-                if (element.is('input')) {
-                    input.on({
-                        'focus': show
-                    });
-                } else if (component) {
-                    component.on('click', toggle);
-                    component.on('mousedown', false);
+                if (!elementIsInput && component) {
+                    componentEvents = {
+                        'click': toggle,
+                        'mousedown': function () {
+                            return false;
+                        }
+                    };
+                    component.on(componentEvents);
                 }
             },
 
             detachDatePickerElementEvents = function () {
-                input.off({
-                    'change': change,
-                    'blur': blur,
-                    'keydown': keydown,
-                    'keyup': keyup,
-                    'focus': options.allowInputToggle ? hide : ''
-                });
-
-                if (element.is('input')) {
-                    input.off({
-                        'focus': show
-                    });
-                } else if (component) {
-                    component.off('click', toggle);
-                    component.off('mousedown', false);
+                input.off(inputEvents);
+                if (componentEvents) {
+                    component.off(componentEvents);
                 }
+                inputEvents = componentEvents = null;
             },
 
             indexGivenDates = function (givenDatesArray) {

--- a/test/publicApiSpec.js
+++ b/test/publicApiSpec.js
@@ -244,6 +244,16 @@ describe('Public API method tests', function () {
             });
         });
 
+        describe('functionality', function () {
+            it('removes error handlers', function () {
+                dtpElement.datetimepicker('destroy');
+                // $._data(element, 'events') is not a public API, so some precautions are needed.
+                // It might be removed or changed in future versions of jQuery.
+                var events = $._data(dtpElement[0], 'events');
+                expect(events).toBeUndefined();
+            });
+        });
+
         describe('access', function () {
             it('returns jQuery object', function () {
                 expect(dtpElement.datetimepicker('destroy')).toBe(dtpElement);


### PR DESCRIPTION
`detachDatePickerElementEvents` didn't always clear all the event handlers. Also this fixes accidental usage of a global variable (`blur`).
