### PR TITLE
Fixed use with browserify

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -39,7 +39,11 @@
         // AMD is used - Register as an anonymous module.
         define(['jquery', 'moment'], factory);
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('jquery'), require('moment'));
+	    if ( typeof window.jQuery === 'undefined' )
+	    {
+		    window.jQuery = window.$ = require('jquery');
+	    }
+        module.exports = factory(window.jQuery, require('moment'));
     } else {
         // Neither AMD nor CommonJS used. Use global variables.
         if (typeof jQuery === 'undefined') {

--- a/src/sass/_bootstrap-datetimepicker.scss
+++ b/src/sass/_bootstrap-datetimepicker.scss
@@ -269,7 +269,7 @@ $bs-datetimepicker-text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25) !default;
                     content: '';
                     display: inline-block;
                     border: solid transparent;
- +                  border-width: 0 0 7px 7px;
+                    border-width: 0 0 7px 7px;
                     border-bottom-color: $bs-datetimepicker-active-bg;
                     border-top-color: $bs-datetimepicker-secondary-border-color-rgba;
                     position: absolute;


### PR DESCRIPTION
There was an erroneous plus sign in the sass file that was stopping it from compiling, so I removed that. I also added a check before requiring jQuery to see if it had already been instantiated to avoid conflicts when using browserify.