### PR TITLE
Fix issue #1065: Can't use minDate with stepping

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -862,6 +862,10 @@
 
                 if (options.stepping !== 1) {
                     targetMoment.minutes((Math.round(targetMoment.minutes() / options.stepping) * options.stepping)).seconds(0);
+
+                    while (options.minDate && targetMoment.isBefore(options.minDate)) {
+                        targetMoment.add(options.stepping, 'minutes');
+                    }
                 }
 
                 if (isValid(targetMoment)) {


### PR DESCRIPTION
This commit fixes an issue with stepping and minDate (issue #1065). If the current moment is rounded down to the nearest stepping, but that value is below minDate, the current date cannot be immediately clicked. Additionally, no value would be pre-populated in the datetimepicker input box. 