### PR TITLE
Hours not set at all when using DTP as TimePicker

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -872,9 +872,7 @@
                     unset = false;
                     update();
                     notifyEvent({
-                        type: 'dp.change',
-                        date: date.clone(),
-                        oldDate: oldDate
+                        type: 'dp.change'
                     });
                 } else {
                     if (!options.keepInvalid) {


### PR DESCRIPTION
using DTP with format: 'HH.mm' doesn't update the hours at all
Removing passing date and oldDate to notifyEvent solves the Problem
(problem seems to be that fillTime is called twice, first with new date and afterwards with old date so HOURS will be changed from new to old immediately)