### PR TITLE
Allow passing a Date()-object to `viewDate()`

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -142,6 +142,10 @@
 
                 if (d === undefined || d === null) {
                     returnMoment = moment(); //TODO should this use format? and locale?
+                } else if (moment.isDate(d) || moment.isMoment(d)) {
+                    // If the date that is passed in is already a Date() or moment() object,
+                    // pass it directly to moment.
+                    returnMoment = moment(d);
                 } else if (hasTimeZone()) { // There is a string to parse and a default time zone
                     // parse with the tz function which takes a default time zone if it is not in the format string
                     returnMoment = moment.tz(d, parseFormats, options.useStrict, options.timeZone);


### PR DESCRIPTION
The internal `getMoment()`-function is forcing dates passed to `viewDate()` to be parsed with the local timeformat even if no format is set (see `actualFormat` in `initFormatting()`). When the datetimepicker is playing together with other components in the larger scope of a page, it can be meaningful to pass in these dates as Javascript `Date`-objects.

This change allows passing `Date()`-objects to `viewDate`.

The problem is illustrated in the [this JSfiddle](http://jsfiddle.net/06mhpqdL/5/).