### PR TITLE
Obey minViewMode when resetting currentViewMode on hide

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -937,7 +937,7 @@
 
                 input.blur();
 
-                currentViewMode = 0;
+                currentViewMode = Math.max(minViewModeNumber, 0);
                 viewDate = date.clone();
 
                 return picker;


### PR DESCRIPTION
The minViewModeNumber is not taken into account when resetting currentViewMode on hide. So the date picker may open in an incorrect view mode.

In my case the format of the picker is"MM/YYYY" which leads to minViewModeNumber = 1. So the picker opens with the correct view mode the first time. But afterwards it will open with view mode 0. :-(

(this time on correct branch)
