### PR TITLE
Fix CommonJS export

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -2631,7 +2631,6 @@
         enabledHours: false,
         viewDate: false
     };
-    if (typeof module !== 'undefined') {
-        module.exports = $.fn.datetimepicker;
-    }
+
+    return $.fn.datetimepicker;
 }));


### PR DESCRIPTION
Export line inside factory function had not restrictive enough check that may
caused global namespace polluting problem during Karma test. Karma has a
`window.module` alias for `angular.mock.module` method used during tests. And as
a result other libs that may check for CommonJS env could erroneously try to use
`require` method which is non-existing in browser env. Example:

``` javascript
  if (typeof module !== 'undefined' && module.exports) {
    // CommonJS
    module.exports = factory(require('angular'));
  }
```

On the other hand this assignment inside factory function was overwritten by
the outcome of factory function itself in following line:

``` javascript
module.exports = factory(require('jquery'), require('moment'));
```

As a result when we had tried to `require('./bootstrap-datetimepicker.js')` in
other script file, we got `undefined`.
