### PR TITLE
Fix Right\Left key press in input text

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1311,8 +1311,7 @@
                     }
                 }
 
-                if (handler) {
-                    handler.call(picker, widget);
+                if (handler && !handler.call(picker, widget)) {
                     e.stopPropagation();
                     e.preventDefault();
                 }
@@ -2565,7 +2564,7 @@
             },
             left: function (widget) {
                 if (!widget) {
-                    return;
+                    return true;
                 }
                 var d = this.date() || this.getMoment();
                 if (widget.find('.datepicker').is(':visible')) {
@@ -2574,7 +2573,7 @@
             },
             right: function (widget) {
                 if (!widget) {
-                    return;
+                    return true;
                 }
                 var d = this.date() || this.getMoment();
                 if (widget.find('.datepicker').is(':visible')) {


### PR DESCRIPTION
When you type the date and want to use the Right or Left keys to navigate through the date text, the navigation didn't work due to the stopPropagation and preventDefault was run after a key press. After the fix the handler.call function returns true only if the propagation is wanted.