### PR TITLE
Fix setValue to work with binders (like Rivets.JS)

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -844,6 +844,7 @@
                 if (!targetMoment) {
                     unset = true;
                     input.val('');
+                    input.trigger('input');
                     element.data('date', '');
                     notifyEvent({
                         type: 'dp.change',
@@ -868,6 +869,7 @@
                     date = targetMoment;
                     //viewDate = date.clone(); // TODO this doesn't work right on first use
                     input.val(date.format(actualFormat));
+                    input.trigger('input');
                     element.data('date', date.format(actualFormat));
                     unset = false;
                     update();
@@ -879,6 +881,7 @@
                 } else {
                     if (!options.keepInvalid) {
                         input.val(unset ? '' : date.format(actualFormat));
+                        input.trigger('input');
                     } else {
                         notifyEvent({
                             type: 'dp.change',


### PR DESCRIPTION
Model binding relies on 'input' event for the following reason.

https://developer.mozilla.org/en-US/docs/Web/Events/input

``
The DOM input event is fired synchronously when the value of an <input> or <textarea> element is changed.
``

https://developer.mozilla.org/en-US/docs/Web/Events/change

``
The change event is fired for <input>, <select>, and <textarea> elements when a change to the element's value is committed by the user. Unlike the input event, the change event is not necessarily fired for each change to an element's value.
``


So, if element value is changed programmatically (i.e. not committed by the user), model binding isn't seeing any change.

http://stackoverflow.com/a/34328350 offers similar workaround for jQuery UI Datepicker

```
function Datepicker(selector, context) {
  $(selector, context).datepicker({
    onSelect: function(date) {
      $(this).trigger('input');
    }
  })
}
```