### PR TITLE
Only use module.exports if it's set

### DIFF
--- a/build/js/bootstrap-datetimepicker.min.js
+++ b/build/js/bootstrap-datetimepicker.min.js
@@ -214,4 +214,4 @@ b=a.extend(!0,{},a.fn.datetimepicker.defaults,b),d.data("DateTimePicker",c(d,b))
 //    var toggle = widget.find('.picker-switch a[data-action="togglePicker"]');
 //    if(toggle.length > 0) toggle.click();
 //},
-"control space":function(a){a&&a.find(".timepicker").is(":visible")&&a.find('.btn[data-action="togglePeriod"]').click()},t:function(){this.date(this.getMoment())},delete:function(){this.clear()}},debug:!1,allowInputToggle:!1,disabledTimeIntervals:!1,disabledHours:!1,enabledHours:!1,viewDate:!1},"undefined"!=typeof module&&(module.exports=a.fn.datetimepicker)});
+"control space":function(a){a&&a.find(".timepicker").is(":visible")&&a.find('.btn[data-action="togglePeriod"]').click()},t:function(){this.date(this.getMoment())},delete:function(){this.clear()}},debug:!1,allowInputToggle:!1,disabledTimeIntervals:!1,disabledHours:!1,enabledHours:!1,viewDate:!1},"undefined"!=typeof module&&"undefined"!=typeof module.exports&&(module.exports=a.fn.datetimepicker)});

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -2617,7 +2617,7 @@
         enabledHours: false,
         viewDate: false
     };
-    if (typeof module !== 'undefined') {
+    if (typeof module === 'object' && typeof module.exports === 'object') {
         module.exports = $.fn.datetimepicker;
     }
 }));


### PR DESCRIPTION
The global variable `module` can exist, even if `module.exports` is not set.