### PR TITLE
Preserve time when clicking today, otherwise use start of day.

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1181,7 +1181,12 @@
                 clear: clear,
 
                 today: function () {
-                    var todaysDate = getMoment();
+                    var todaysDate = getMoment().startOf('d');
+
+                    if (hasTime()) {
+                        todaysDate.set({h:date.hour(), m: date.minute(), s: date.second(), ms: date.millisecond()});
+                    }
+
                     if (isValid(todaysDate, 'd')) {
                         setValue(todaysDate);
                     }


### PR DESCRIPTION
Currently, clicking the "today" button uses the current time, which is dependent on the browser timezone.  This forces the time to 00:00 unless using a format which includes the time, in which case the selected time is preserved (instead of being reset to the current time).