### PR TITLE
fixed bug: widget force show day mode

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -947,7 +947,7 @@
 
                 input.blur();
 
-                currentViewMode = 0;
+                currentViewMode = Math.max(viewModes.indexOf(options.viewMode), minViewModeNumber);
                 viewDate = date.clone();
 
                 return picker;


### PR DESCRIPTION
my options is format: 'YYYY-MM', viewMode: 'months', it will open month view in first time. but when i reopen the picker, it's forced open day view. I think this is a bug.