### PR TITLE
Add an option to set the expanded class of Bootstraps collapse

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -203,6 +203,24 @@ Takes a `boolean`. If set to `false` the picker will display similar to `sideByS
 ----------------------
 
 
+### collapseExpandedClass
+
+	Default: 'in'
+
+Define a Bootstraps collapse class, used to set if the collapse is expanded or not.
+
+#### collapseExpandedClass()
+
+Returns a `string` of the `options.collapseExpandedClass`.
+
+
+#### collapseExpandedClass(collapseExpandedClass)
+
+Takes a `string`.
+
+----------------------
+
+
 ### locale
 
 	Default: moment.locale()

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -365,7 +365,7 @@
                     content.append(toolbar);
                 }
                 if (hasDate()) {
-                    content.append($('<li>').addClass((options.collapse && hasTime() ? 'collapse in' : '')).append(dateView));
+                    content.append($('<li>').addClass((options.collapse && hasTime() ? 'collapse ' + options.collapseExpandedClass : '')).append(dateView));
                 }
                 if (options.toolbarPlacement === 'default') {
                     content.append(toolbar);
@@ -1101,8 +1101,8 @@
                 togglePicker: function (e) {
                     var $this = $(e.target),
                         $parent = $this.closest('ul'),
-                        expanded = $parent.find('.in'),
-                        closed = $parent.find('.collapse:not(.in)'),
+                        expanded = $parent.find('.' + options.collapseExpandedClass),
+                        closed = $parent.find('.collapse:not(.' + options.collapseExpandedClass + ')'),
                         collapseData;
 
                     if (expanded && expanded.length) {
@@ -1869,6 +1869,23 @@
             return picker;
         };
 
+        picker.collapseExpandedClass = function (collapseExpandedClass) {
+            if (arguments.length === 0) {
+                return options.collapseExpandedClass;
+            }
+
+            if (typeof collapseExpandedClass !== 'string' || !collapseExpandedClass) {
+                throw new TypeError('collapseExpandedClass() expects a string parameter');
+            }
+
+            if (options.collapseExpandedClass === collapseExpandedClass) {
+                return picker;
+            }
+
+            options.collapseExpandedClass = collapseExpandedClass;
+            return picker;
+        };
+
         picker.icons = function (icons) {
             if (arguments.length === 0) {
                 return $.extend({}, options.icons);
@@ -2456,6 +2473,7 @@
         maxDate: false,
         useCurrent: true,
         collapse: true,
+        collapseExpandedClass: 'in',
         locale: moment.locale(),
         defaultDate: false,
         disabledDates: false,

--- a/test/publicApiSpec.js
+++ b/test/publicApiSpec.js
@@ -551,6 +551,26 @@ describe('Public API method tests', function () {
         });
     });
 
+    describe('collapseExpandedClass() function', function () {
+        describe('existence', function () {
+            it('is defined', function () {
+                expect(dtp.collapseExpandedClass).toBeDefined();
+            });
+        });
+
+        describe('access', function () {
+            it('gets collapse expanded class', function () {
+                expect(dtpElement.datetimepicker('collapseExpandedClass')).toBe('in');
+            });
+
+            it('sets collapse expanded class', function () {
+                var collapseExpandedClass = 'show';
+                expect(dtpElement.datetimepicker('collapseExpandedClass', collapseExpandedClass)).toBe(dtpElement);
+                expect(dtpElement.datetimepicker('collapseExpandedClass')).toBe(collapseExpandedClass);
+            });
+        });
+    });
+
     describe('locale() function', function () {
         describe('functionality', function () {
             it('it has the same locale as the global moment locale with default options', function () {


### PR DESCRIPTION
Solve problems with bootstrap 4.

In Bootstrap 4, the .in class will be renamed to .show.

Maybe this class must be seted by user.