### PR TITLE
Fix dis/enabledDates updating by deep-extending dates arg

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1610,10 +1610,14 @@
                 update();
                 return picker;
             }
-            if (!(dates instanceof Array)) {
+
+            // Deep extend to prevent mutation
+            var disabledDates = $.extend(true, [], dates);
+
+            if (!(disabledDates instanceof Array)) {
                 throw new TypeError('disabledDates() expects an array parameter');
             }
-            options.disabledDates = indexGivenDates(dates);
+            options.disabledDates = indexGivenDates(disabledDates);
             options.enabledDates = false;
             update();
             return picker;
@@ -1637,10 +1641,14 @@
                 update();
                 return picker;
             }
-            if (!(dates instanceof Array)) {
+
+            // Deep extend to prevent mutation
+            var enabledDates = $.extend(true, [], dates);
+
+            if (!(enabledDates instanceof Array)) {
                 throw new TypeError('enabledDates() expects an array parameter');
             }
-            options.enabledDates = indexGivenDates(dates);
+            options.enabledDates = indexGivenDates(enabledDates);
             options.disabledDates = false;
             update();
             return picker;


### PR DESCRIPTION
#1257 #1941

The `dates` arg for dis/enabledDates gets mutated, so calling
`datetimepicker.enabledDates([])` throws the TypeError. I believe
`dates` gets mutated into an Object when it’s indexed, and the issues
mentioned seem to point to this.

Deep-extending `dates` into a new `en/disabledDates` var fixes the
problem for me. Preventing the mutation at its source would be better,
but I can’t figure out where this occurs - maybe `indexGivenDates()`,
or by storing them in `options.enabledDates`?

This is my first public PR, feedback appreciated :+1: