### PR TITLE
Add support for Jquery ^3.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
   },
   "peerDependencies": {
     "bootstrap": "^3.3",
-    "jquery": "^1.8.3 || ^2.0",
+    "jquery": "^1.8.3 || ^2.0 || ^3.0",
     "moment": "^2.10",
     "moment-timezone": "^0.4.0"
   },
   "dependencies": {
     "bootstrap": "^3.3",
-    "jquery": "^1.8.3 || ^2.0",
+    "jquery": "^1.8.3 || ^2.0 || ^3.0",
     "moment": "^2.10",
     "moment-timezone": "^0.4.0"
   },


### PR DESCRIPTION
Should work out of the box. 

Did run the `eval npm install` and didn't see any problem with running Jquery 3.0 and above with the Bootstrap 3 Date/Time Picker.