### PR TITLE
Updating markup for WCAGAA Compliance

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -198,17 +198,19 @@
 
             getDatePickerTemplate = function () {
                 var headTemplate = $('<thead>')
-                        .append($('<tr>')
-                            .append($('<th>').addClass('prev').attr('data-action', 'previous')
-                                .append($('<span>').addClass(options.icons.previous))
-                                )
-                            .append($('<th>').addClass('picker-switch').attr('data-action', 'pickerSwitch').attr('colspan', (options.calendarWeeks ? '6' : '5')))
-                            .append($('<th>').addClass('next').attr('data-action', 'next')
-                                .append($('<span>').addClass(options.icons.next))
-                                )
-                            ),
+                        .append($('<span>').addClass('datepicker-header-day'))
+                        .append('<br>')
+                        .append($('<tr class="datepicker-header-navigation">')
+                          .append($('<td>').addClass('prev').attr('data-action', 'previous')
+                            .append('<svg class="icon arrow left"><use xlink:href="#arrow"/></svg>')
+                          )
+                          .append($('<td>').addClass('picker-switch').attr('data-action', 'pickerSwitch').attr('colspan', (options.calendarWeeks ? '6' : '5')))
+                          .append($('<td>').addClass('next').attr('data-action', 'next')
+                            .append('<svg class="icon arrow right"><use xlink:href="#arrow"/></svg>')
+                          )
+                        ),
                     contTemplate = $('<tbody>')
-                        .append($('<tr>')
+                        .append($('<tr class="datepicker-body-content">')
                             .append($('<td>').attr('colspan', (options.calendarWeeks ? '8' : '7')))
                             );
 
@@ -584,12 +586,12 @@
                     spans.push($('<span>').attr('data-action', 'selectMonth').addClass('month').text(monthsShort.format('MMM')));
                     monthsShort.add(1, 'M');
                 }
-                widget.find('.datepicker-months td').empty().append(spans);
+                widget.find('.datepicker-months .datepicker-body-content td').empty().append(spans);
             },
 
             updateMonths = function () {
                 var monthsView = widget.find('.datepicker-months'),
-                    monthsViewHeader = monthsView.find('th'),
+                    monthsViewHeader = monthsView.find('.datepicker-header-navigation td'),
                     months = monthsView.find('tbody').find('span');
 
                 monthsViewHeader.eq(0).find('span').attr('title', options.tooltips.prevYear);
@@ -622,7 +624,7 @@
 
             updateYears = function () {
                 var yearsView = widget.find('.datepicker-years'),
-                    yearsViewHeader = yearsView.find('th'),
+                    yearsViewHeader = yearsView.find('.datepicker-header-navigation td'),
                     startYear = viewDate.clone().subtract(5, 'y'),
                     endYear = viewDate.clone().add(6, 'y'),
                     html = '';
@@ -648,12 +650,12 @@
                     startYear.add(1, 'y');
                 }
 
-                yearsView.find('td').html(html);
+                yearsView.find('.datepicker-body-content td').html(html);
             },
 
             updateDecades = function () {
                 var decadesView = widget.find('.datepicker-decades'),
-                    decadesViewHeader = decadesView.find('th'),
+                    decadesViewHeader = decadesView.find('.datepicker-header-navigation td'),
                     startDecade = moment({y: viewDate.year() - (viewDate.year() % 100) - 1}),
                     endDecade = startDecade.clone().add(100, 'y'),
                     startedAt = startDecade.clone(),
@@ -687,7 +689,8 @@
 
             fillDate = function () {
                 var daysView = widget.find('.datepicker-days'),
-                    daysViewHeader = daysView.find('th'),
+                    datepickerHeader = daysView.find('.datepicker-header-day'),
+                    daysViewHeader = daysView.find('.datepicker-header-navigation td'),
                     currentDate,
                     html = [],
                     row,

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -198,16 +198,14 @@
 
             getDatePickerTemplate = function () {
                 var headTemplate = $('<thead>')
-                        .append($('<span>').addClass('datepicker-header-day'))
-                        .append('<br>')
                         .append($('<tr class="datepicker-header-navigation">')
                           .append($('<td>').addClass('prev').attr('data-action', 'previous')
-                            .append('<svg class="icon arrow left"><use xlink:href="#arrow"/></svg>')
+                          	.append($('<span>').addClass(options.icons.previous))
                           )
                           .append($('<td>').addClass('picker-switch').attr('data-action', 'pickerSwitch').attr('colspan', (options.calendarWeeks ? '6' : '5')))
                           .append($('<td>').addClass('next').attr('data-action', 'next')
-                            .append('<svg class="icon arrow right"><use xlink:href="#arrow"/></svg>')
-                          )
+                          	.append($('<span>').addClass(options.icons.next))
+                          	)
                         ),
                     contTemplate = $('<tbody>')
                         .append($('<tr class="datepicker-body-content">')
@@ -689,7 +687,6 @@
 
             fillDate = function () {
                 var daysView = widget.find('.datepicker-days'),
-                    datepickerHeader = daysView.find('.datepicker-header-day'),
                     daysViewHeader = daysView.find('.datepicker-header-navigation td'),
                     currentDate,
                     html = [],


### PR DESCRIPTION
I was testing the compliance of the HTML markup that is created by the plugin using the squizlabs checker (http://squizlabs.github.io/HTML_CodeSniffer/) and got 1 error. 

The issue stems from using too many rows of TH tags.  I wound up removing the TH tags around the controls (next, previous, and picker switch) and changing them to TD tags. After doing this I found that I had to also update some of the scripting selectors and markup with classes to call the proper TD tags for later functions. They use NTH style selectors.