### PR TITLE
added api to programmatically change the view in inline mode

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -2402,7 +2402,7 @@
             var elems = $('li', widget) 
             picker.setInlineView.cache = {
                 firstLi : elems.first(),
-                span: elems.find('span'),
+                span: elems.first().next().find('span'),
                 lastLi : elems.last()
             };
         }

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -2401,7 +2401,7 @@
             show();
             var elems = $('li', widget) 
             picker.setInlineView.cache = {
-                firstLi : elems.first()
+                firstLi : elems.first(),
                 span: elems.first().next().first(),
                 lastLi : elems.last()
             };

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -2402,7 +2402,7 @@
             var elems = $('li', widget) 
             picker.setInlineView.cache = {
                 firstLi : elems.first(),
-                span: elems.first().next().first(),
+                span: elems.find('span'),
                 lastLi : elems.last()
             };
         }

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1428,7 +1428,10 @@
                 if (!unset) {
                     setValue(date);
                 }
-            };
+            },
+            //variables for setInlineView
+            setInlineViewCache,
+            elems;
 
         /********************************************************************************
          *
@@ -2332,16 +2335,15 @@
          * @param {Takes string, 'datepicker', 'timepicker'} newDate
          * @returns {picker instance}
          */
-        picker.setInlineView = function(view) {
+        picker.setInlineView = function (view) {
             if (picker.options().inline) {
                 var cache = picker.setInlineView.cache;
-                
                 if (view === 'datepicker') {
                     //show the date picker
                     cache.firstLi.collapse('show');
                     cache.lastLi.collapse('hide');
                     cache.span.removeClass('glyphicon-calendar').addClass('glyphicon-time');
-                } else if(view === 'timepicker') {
+                } else if (view === 'timepicker') {
                     //show the time picker
                     cache.firstLi.collapse('hide');
                     cache.lastLi.collapse('show');
@@ -2399,12 +2401,13 @@
         }
         if (options.inline) {
             show();
-            var elems = $('li', widget) 
-            picker.setInlineView.cache = {
+            elems = $('li', widget);
+            setInlineViewCache = {
                 firstLi : elems.first(),
                 span: elems.first().next().find('span'),
                 lastLi : elems.last()
             };
+            picker.setInlineView.cache = setInlineViewCache;
         }
         return picker;
     };
@@ -2436,7 +2439,6 @@
      * @memberOf jQuery.fn
      */
     $.fn.datetimepicker = function (options) {
-        console.log('foo')
         options = options || {};
 
         var args = Array.prototype.slice.call(arguments, 1),

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -2327,6 +2327,17 @@
             return picker;
         };
 
+        picker.setInlineView = function(view) {
+            if (picker.options().inline) {
+                if (view === 'datepicker') {
+                    //show the date picker
+                } else if(view === 'timepicker') {
+                    //show the time picker
+                }
+            }
+            return picker;
+        };
+
         // initializing element and component attributes
         if (element.is('input')) {
             input = element;
@@ -2406,6 +2417,7 @@
      * @memberOf jQuery.fn
      */
     $.fn.datetimepicker = function (options) {
+        console.log('foo')
         options = options || {};
 
         var args = Array.prototype.slice.call(arguments, 1),

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -2327,12 +2327,25 @@
             return picker;
         };
 
+        /**
+         * Sets the view in inline mode
+         * @param {Takes string, 'datepicker', 'timepicker'} newDate
+         * @returns {picker instance}
+         */
         picker.setInlineView = function(view) {
             if (picker.options().inline) {
+                var cache = picker.setInlineView.cache;
+                
                 if (view === 'datepicker') {
                     //show the date picker
+                    cache.firstLi.collapse('show');
+                    cache.lastLi.collapse('hide');
+                    cache.span.removeClass('glyphicon-calendar').addClass('glyphicon-time');
                 } else if(view === 'timepicker') {
                     //show the time picker
+                    cache.firstLi.collapse('hide');
+                    cache.lastLi.collapse('show');
+                    cache.span.removeClass('glyphicon-time').addClass('glyphicon-calendar');
                 }
             }
             return picker;
@@ -2386,6 +2399,12 @@
         }
         if (options.inline) {
             show();
+            var elems = $('li', widget) 
+            picker.setInlineView.cache = {
+                firstLi : elems.first()
+                span: elems.first().next().first(),
+                lastLi : elems.last()
+            };
         }
         return picker;
     };


### PR DESCRIPTION
Love this picker. When I used it in my project, I found something amiss. 

When you initialize the plugin with inline as true (only) there is no external way of changing the view. By default it shows up the datepicker. Hence if I want to change the view to a timepicker my only option is to trigger a click on the span element which shows the time icon. 

I've noticed that there is no api to this effect. So I have added it.

The api call is `setInlineView` - it should be called with one argument (string) - either `datepicker` or `timepicker`

Running plunk: http://plnkr.co/edit/C0TbwenqXLboaVk1e2ta?p=preview