### PR TITLE
Passing the string "false" to min/maxDate options.

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1698,7 +1698,7 @@
             if (typeof maxDate === 'string') {
                 if (maxDate === 'now' || maxDate === 'moment') {
                     maxDate = getMoment();
-                }else if(maxDate.toLowerCase() === "false"){
+                }else if(maxDate.toLowerCase() === 'false'){
                     options.maxDate = false;
                     update();
                     return picker;
@@ -1738,7 +1738,7 @@
             if (typeof minDate === 'string') {
                 if (minDate === 'now' || minDate === 'moment') {
                     minDate = getMoment();
-                }else if(minDate.toLowerCase() === "false"){
+                }else if(minDate.toLowerCase() === 'false'){
                     options.minDate = false;
                     update();
                     return picker;

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1698,7 +1698,7 @@
             if (typeof maxDate === 'string') {
                 if (maxDate === 'now' || maxDate === 'moment') {
                     maxDate = getMoment();
-                }else if(maxDate.toLowerCase() === 'false'){
+                } else if (maxDate.toLowerCase() === 'false') {
                     options.maxDate = false;
                     update();
                     return picker;
@@ -1738,7 +1738,7 @@
             if (typeof minDate === 'string') {
                 if (minDate === 'now' || minDate === 'moment') {
                     minDate = getMoment();
-                }else if(minDate.toLowerCase() === 'false'){
+                } else if (minDate.toLowerCase() === 'false') {
                     options.minDate = false;
                     update();
                     return picker;

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1698,6 +1698,10 @@
             if (typeof maxDate === 'string') {
                 if (maxDate === 'now' || maxDate === 'moment') {
                     maxDate = getMoment();
+                }else if(maxDate.toLowerCase() === "false"){
+                    options.maxDate = false;
+                    update();
+                    return picker;
                 }
             }
 
@@ -1734,6 +1738,10 @@
             if (typeof minDate === 'string') {
                 if (minDate === 'now' || minDate === 'moment') {
                     minDate = getMoment();
+                }else if(minDate.toLowerCase() === "false"){
+                    options.minDate = false;
+                    update();
+                    return picker;
                 }
             }
 


### PR DESCRIPTION
This was a very small change I added to make my life a tiny bit easier when filling these options with php. In my specific use case, it was easier to just pass a string containing "false" than it was to sometimes pass string and sometimes pass a bool. Might come in handy for others?