### PR TITLE
Add touchstart handler to fix fastclick issue

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -934,7 +934,7 @@
                 widget.hide();
 
                 $(window).off('resize', place);
-                widget.off('click', '[data-action]');
+                widget.off('click touchstart', '[data-action]');
                 widget.off('mousedown', false);
 
                 widget.remove();
@@ -1245,7 +1245,7 @@
                 showMode();
 
                 $(window).on('resize', place);
-                widget.on('click', '[data-action]', doAction); // this handles clicks on the widget
+                widget.on('click touchstart', '[data-action]', doAction); // this handles clicks and touchstart on the widget
                 widget.on('mousedown', false);
 
                 if (component && component.hasClass('btn')) {
@@ -1346,7 +1346,7 @@
                         'focus': show
                     });
                 } else if (component) {
-                    component.on('click', toggle);
+                    component.on('click touchstart', toggle);
                     component.on('mousedown', false);
                 }
             },
@@ -1365,7 +1365,7 @@
                         'focus': show
                     });
                 } else if (component) {
-                    component.off('click', toggle);
+                    component.off('click touchstart', toggle);
                     component.off('mousedown', false);
                 }
             },


### PR DESCRIPTION
This will stop iOS devices from closing the datetimepicker immediately after click without any action and adds support for fastclick.

## What the change does
It adds the handler `touchstart`. This new handler executes the same actions as the handler `click`.

## Use case
Enable any web app which uses fastclick (or similar) to use this awesome library. Without this fix the library isn't functioning at all.

## Fixes issue:
#720 

## Tests run with output
```
204 specs in 1.36s.
>> 0 failures
```

## Other libraries doing the same fix
https://github.com/uxsolutions/bootstrap-datepicker/blob/v1.7.0-RC1/js/bootstrap-datepicker.js#L424
