### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -228,10 +228,10 @@ Bug squashing
 * Fix for #46, fixed active date highlighting
 * Fix for #47, `change.dp` event to also include the previous date.
 
-####2.0.1
+#### 2.0.1
 * New event `error.dp` fires when plugin cannot parse date or when increase/descreasing hours/minutes to a disabled date.
 * Minor fixes
 
-####2.0.0
+#### 2.0.0
 * `disabledDates` is now an option to set the disabled dates. It accepts date objects like `new Date("November 12, 2013 00:00:00")` and `12/25/2013' and `moment` date objects
 * Events are easier to use

--- a/docs/Functions.md
+++ b/docs/Functions.md
@@ -5,7 +5,7 @@
     All functions are accessed via the <code>data</code> attribute e.g. <code>$('#datetimepicker').data("DateTimePicker").FUNCTION()</code>
 </div>
 
-###destroy()
+### destroy()
 
 Destroys the widget and removes all attached event listeners
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -20,7 +20,7 @@ Takes an object variable with option key:value properties and configures the com
 
  Returns the component's model current date, a `moment` object or `null` if not set.
 
-####date([newDate])
+#### date([newDate])
 
  Takes `string, Date, moment, null` parameter and sets the components model current moment to it. Passing a `null` value unsets the components model current moment. Parsing of the newDate parameter is made using moment library with the `options.format` and `options.useStrict` components configuration.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-#Bootstrap 3 Datepicker v4 Docs
+# Bootstrap 3 Datepicker v4 Docs
 
 <div class="alert alert-info">
     <strong>Note</strong>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
