### PR TITLE
Fix non start of day date when pick time is disabled

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1045,9 +1045,13 @@
                     if ($(e.target).is('.new')) {
                         day.add(1, 'M');
                     }
-                    setValue(day.date(parseInt($(e.target).text(), 10)));
-                    if (!hasTime() && !options.keepOpen && !options.inline) {
-                        hide();
+                    if (!hasTime()) {
+                        setValue(day.date(parseInt($(e.target).text(), 10)).startOf('day'));
+                        if (!options.keepOpen && !options.inline) {
+                            hide();
+                        }
+                    } else {
+                        setValue(day.date(parseInt($(e.target).text(), 10)));
                     }
                 },
 


### PR DESCRIPTION
## **What the PR does**
Fixes #2083.
Make the datetime picker to create a start of day date when the time picker is disabled.

## **Why**
This was how it worked until 4.17.42 where this operating was unintentionally broken.

## **More**
Tests ouput:
```
204 specs in 0.739s.
>> 0 failures
```