### PR TITLE
allow newer version of moment-timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "bootstrap": "^3.3",
     "jquery": "^1.8.3 || ^2.0 || ^3.0",
     "moment": "^2.10",
-    "moment-timezone": "^0.4.0 || ^0.5.0"
+    "moment-timezone": "^0.5.0"
   },
   "description": "A date/time picker component designed to work with Bootstrap 3 and Momentjs. For usage, installation and demos see Project Site on GitHub",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "bootstrap": "^3.3",
     "jquery": "^1.8.3 || ^2.0 || ^3.0",
     "moment": "^2.10",
-    "moment-timezone": "^0.4.0"
+    "moment-timezone": "^0.4.0 || ^0.5.0"
   },
   "dependencies": {
     "bootstrap": "^3.3",
     "jquery": "^1.8.3 || ^2.0 || ^3.0",
     "moment": "^2.10",
-    "moment-timezone": "^0.5.0"
+    "moment-timezone": "^0.4.0 || ^0.5.0"
   },
   "description": "A date/time picker component designed to work with Bootstrap 3 and Momentjs. For usage, installation and demos see Project Site on GitHub",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "bootstrap": "^3.3",
     "jquery": "^1.8.3 || ^2.0 || ^3.0",
     "moment": "^2.10",
-    "moment-timezone": "^0.4.0"
+    "moment-timezone": "^0.4.0 || ^0.5.0"
   },
   "description": "A date/time picker component designed to work with Bootstrap 3 and Momentjs. For usage, installation and demos see Project Site on GitHub",
   "devDependencies": {


### PR DESCRIPTION
The version of moment-timezone specified is old enough that this is breaking some of my builds.

Please merge and publish an update? ❤️ 