### PR TITLE
Ignore excess files in Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,10 +25,7 @@
   "license": "MIT",
   "private": false,
   "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
-    "test",
-    "tests"
+    "**/*",
+    "!/build/*"
   ]
 }


### PR DESCRIPTION
Bower is designed to install only files that are used by a browser. When a bootstrap-datetimepicker package is installed using Bower, a lot of excess files are downloaded and take disc space: `docs`, `src`, `tasks` and others. They are not used by a browser.

So I suggest to amend the `bower.json` file to tell Bower that only the files in the `build` directory are required for a browser.