### PR TITLE
Fix of issue #1690

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -912,6 +912,9 @@
              * Hides the widget. Possibly will emit dp.hide
              */
             hide = function () {
+             
+                keyState = {};
+             
                 var transitioning = false;
                 if (!widget) {
                     return picker;


### PR DESCRIPTION
To reproduce issue #1690 in JSFiddle http://jsfiddle.net/Eonasdan/0Ltv25o8/
1. Klick into datetimepicker1 so that it gets keyboard focus
2. Press arrow down key => widget is shown
3. Press backspace 9 times
4. Press tab key 2 times
5. Klick into datetimepicker1 so that it gets keyboard focus
6. Press down key
Error: widget is not shown

**Explanation:**
If you exit the input field using the tab key then KeyUp doesn't register the last key event . This leads to stale entries in `keyState` with value 'p' correspondiing to keys which are no longer pressed.

If you now press a key with key binding then array `pressedKeys` in function `keydown` will get populated with old values (see line 1291) which leads to `(keyBindKeys.length === pressedKeys.length)` being evaluated to `false` (see line 1301).

Therefore key bindings will never get invoked again. This error is described in issue #1690. 
 
**Solution:** clear `keyState ` whenever widget is hidden.