### PR TITLE
Update function useCurrent, added 'dayend' option.

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1212,6 +1212,9 @@
                         'day': function (m) {
                             return m.hours(0).seconds(0).minutes(0);
                         },
+                        'dayend': function (m) {
+                            return m.hours(23).seconds(59).minutes(59);
+                        },
                         'hour': function (m) {
                             return m.seconds(0).minutes(0);
                         },
@@ -1834,7 +1837,7 @@
         };
 
         picker.useCurrent = function (useCurrent) {
-            var useCurrentOptions = ['year', 'month', 'day', 'hour', 'minute'];
+            var useCurrentOptions = ['year', 'month', 'day', 'dayend', 'hour', 'minute'];
             if (arguments.length === 0) {
                 return options.useCurrent;
             }


### PR DESCRIPTION
'dayend' option provides hour 23:59:59.

![image](https://user-images.githubusercontent.com/15981323/36098668-f0cff942-0fe6-11e8-80b3-c156cf8f8029.png)

```
$('#my-input-initial-date').datetimepicker({
        format: 'DD/MM/YYYY HH:mm',
        locale: 'pt-br',
        useCurrent: 'day'
    });
    $('#my-input-end-date').datetimepicker({
        format: 'DD/MM/YYYY HH:mm',
        locale: 'pt-br',
        useCurrent: 'dayend'
    });
```